### PR TITLE
Fixes other problems and job multiple-income problem

### DIFF
--- a/docassemble/VTFeeWaiver/al_income_move.py
+++ b/docassemble/VTFeeWaiver/al_income_move.py
@@ -1123,14 +1123,14 @@ class ALItemizedJob(DAObject):
 
         # Both the job and the item itself need to be hourly to be
         # calculated as hourly
-        is_hourly = self.is_hourly and hasattr(item, "is_hourly") and item.is_hourly
+        is_hourly = hasattr(item, "is_hourly") and item.is_hourly
         value = item.total()
 
         # Use the appropriate calculation
         if is_hourly:
             # NOTE: fixes a bug that was present < 0.8.2
             try:
-                hours_per_period = Decimal(self.hours_per_period)
+                hours_per_period = Decimal(item.hours_per_period)
             except:
                 log(
                     word(
@@ -1138,8 +1138,8 @@ class ALItemizedJob(DAObject):
                     ),
                     "danger",
                 )
-                delattr(self, "hours_per_period")
-                self.hours_per_period  # Will cause another exception
+                delattr(item, "hours_per_period")
+                item.hours_per_period  # Will cause another exception
 
             return (
                 value * Decimal(hours_per_period) * Decimal(frequency_to_use)

--- a/docassemble/VTFeeWaiver/al_income_move.py
+++ b/docassemble/VTFeeWaiver/al_income_move.py
@@ -1,0 +1,1412 @@
+# Based on https://github.com/GBLS/docassemble-income/blob/master/docassemble/income/income.py
+
+from docassemble.base.util import (
+    DAObject,
+    DADict,
+    DAList,
+    DAOrderedDict,
+    DAEmpty,
+    Individual,
+    comma_list,
+    get_locale,
+    word,
+    log,
+    object_name_convert,
+    value,
+)
+from decimal import Decimal
+import re
+import datetime
+import docassemble.base.functions
+import json
+from typing import Any, Dict, Callable, List, Optional, Set, Union, Tuple, Mapping
+
+__all__ = [
+    "times_per_year",
+    "recent_years",
+    "ALIncome",
+    "ALIncomeList",
+    "ALExpense",
+    "ALExpenseList",
+    "ALJob",
+    "ALJobList",
+    "ALAsset",
+    "ALAssetList",
+    "ALVehicle",
+    "ALVehicleList",
+    "ALSimpleValue",
+    "ALSimpleValueList",
+    "ALItemizedValue",
+    "ALItemizedValueDict",
+    "ALItemizedJob",
+    "ALItemizedJobList",
+]
+
+
+def _currency_float_to_decimal(value: Union[str, float]) -> Decimal:
+    """Given a float (that was set by a docassemble currency datatype, so
+    rounded to the nearest `fractional_digit` decimal places), returns the
+    exact decimal value, without floating point representation errors
+    """
+    if isinstance(value, float):
+        # Print out the value of the float, rounded to the smallest allowable amount in the
+        # locale currency, and use this value to make the exact Decimal value
+        digits = get_locale("frac_digits")
+        return Decimal(f"{value:.{digits}f}")
+    else:
+        return Decimal(value)
+
+
+def times_per_year(
+    times_per_year_list: List[Tuple[int, str]], times_per_year: float
+) -> str:
+    """
+    Get the lower-case textual description that matches a time period contained
+    in a "times per year" list.
+
+    The goal of this function is to allow you to reflect the user's selection
+    back to them, either on screen or in a document.
+
+    In `al_income.yml` there is a default `times_per_year_list`, but the list
+    that you use must be passed as a parameter as it's common to want to
+    customize this for a given financial statement.
+
+    For example: if the `times_per_year` is 12, it will return "monthly" from
+    the default `times_per_year_list`.
+
+    If the times per year does not exist in the given list, it will return a
+    literal string like "five times per year".
+
+    Fractional or floating point-based times_per_year are permissible in the
+    times_per_year_list, although they are not commonly used. E.g., `.5` would
+    represent "every two years". Items not contained in the list (to provide a
+    specific lookup name) will have a string representation that is rounded to
+    the nearest whole integer.
+    """
+    try:
+        for row in times_per_year_list:
+            if float(times_per_year) == float(row[0]):
+                return row[1].lower()
+        return (
+            docassemble.base.functions.nice_number(int(times_per_year), capitalize=True)
+            + " "
+            + docassemble.base.functions.word("times per year")
+        )
+    except:
+        return str(times_per_year)
+
+
+def recent_years(
+    past: int = 25, order: str = "descending", future: int = 1
+) -> List[int]:
+    """
+    Returns a list of the most recent past years, continuing into the future.
+    Defaults to most recent 15 years+1. Useful to populate a combobox of years
+    where the most recent ones are most likely. E.g. automobile years or
+    birthdate.
+
+    Keyword parameters:
+    * past {float} The number of past years to list, including the current year.
+        The default is 15
+    * order {string} 'descending' or 'ascending'. Default is `descending`.
+    * future (defaults to 1).
+    """
+    now = datetime.datetime.now()
+    if order == "ascending":
+        return list(range(now.year - past, now.year + future, 1))
+    else:
+        return list(range(now.year + future, now.year - past, -1))
+
+
+class ALPeriodicAmount(DAObject):
+    """
+    Represents an amount (could be an income or an expense depending on the context)
+    that reoccurs some times per year. E.g, to express a weekly period, use 52. The default
+    is 1 (a year).
+
+    Attributes:
+    .value {str | float | Decimal} A number representing an amount of money accumulated during
+        the `times_per_year` of this income.
+    .times_per_year {float | Decimal} Represents a number of the annual frequency of
+        the income. E.g. 12 for a monthly income.
+    .source {str} (Optional) The "source" of the income, like a "job" or a "house".
+    .display_name {str} (Optional) If present, will have a translated string to show the
+        user, as opposed to a raw english string from the program
+    """
+
+    def __str__(self) -> str:
+        """Returns the income's `.total()` as string, not its object name."""
+        return str(self.total())
+
+    def total(self, times_per_year: float = 1) -> Decimal:
+        """
+        Returns the income over the specified times_per_year,
+
+        To calculate `.total()`, an ALPeriodicAmount must have a `.times_per_year` and `.value`.
+        """
+        val = _currency_float_to_decimal(self.value)
+        return (val * Decimal(self.times_per_year)) / Decimal(times_per_year)
+
+
+class ALIncome(ALPeriodicAmount):
+    """
+    Represents an income which may have an hourly rate or a salary. Hourly rate
+    incomes must include hours per period (times per year). Period is some
+    denominator of a year. E.g, to express a weekly period, use 52. The default
+    is 1 (a year).
+
+    Attributes:
+    .value {str | float | Decimal} A number representing an amount of money accumulated during
+        the `times_per_year` of this income.
+    .times_per_year {float | Decimal} Represents a number of the annual frequency of
+        the income. E.g. 12 for a monthly income.
+    .is_hourly {bool} (Optional) True if the income is hourly.
+    .hours_per_period {float | Decimal} (Optional) If the income is hourly, the number of
+        hours during the annual frequency of this job. E.g. if the annual
+        frequency is 52 (weekly), the hours per week might be 50. That is, 50
+        hours per week. This attribute is required if `.is_hourly` is True.
+    .source {str} (Optional) The "source" of the income, like a "job" or a "house".
+    .owner {str} (Optional) Full name of the income's owner as a single string.
+    """
+
+    def total(self, times_per_year: float = 1) -> Decimal:
+        """
+        Returns the income over the specified times_per_year, taking into account
+        hours per period for hourly items. For example, for an hourly income of 10
+        an hour, 40 hours a week, `income.total(1)` would be 20,800, the yearly income,
+        and `income.total(52)` would be 400, the weekly income.
+
+        To calculate `.total()`, an ALIncome must have a `.times_per_year` and `.value`.
+        It can also have `.is_hourly` and `.hours_per_period`.
+        """
+        if hasattr(self, "is_hourly") and self.is_hourly:
+            val = _currency_float_to_decimal(self.value)
+            return (
+                val * Decimal(self.hours_per_period) * Decimal(self.times_per_year)
+            ) / Decimal(times_per_year)
+        else:
+            return super().total(times_per_year=times_per_year)
+
+
+class ALExpense(ALPeriodicAmount):
+    """Not much changes from ALPeriodic Amount, just the generic object questions"""
+
+    pass
+
+
+SourceType = Union[Set[str], List[str], str]
+
+
+def _to_set(s: Optional[Union[Set, List, str]]) -> Set:
+    """Converts a str, list of strings, or set of strings into a set of strings,
+    which can be used to filter items in ALIncome classes.
+
+    This is for internal use meant to ensure that `source` input is always a set.
+    """
+    if s is None:
+        return set()
+    if isinstance(s, set):
+        return s
+    if isinstance(s, list):
+        return set(s)
+    if isinstance(s, str):
+        return set([s])
+    return set()
+
+
+def _source_to_callable(
+    source: Optional[SourceType] = None, exclude_source: Optional[SourceType] = None
+) -> Callable[[str], bool]:
+    """Combines both a positive and negative lists into a single set that should be tested for inclusion"""
+    exclude_set = _to_set(exclude_source)
+    include_set = _to_set(source).difference(exclude_set)
+    if include_set:
+        return lambda s: s in include_set
+    else:
+        if exclude_set:
+            return lambda s: s not in exclude_set
+        else:
+            return lambda s: True
+
+
+class ALIncomeList(DAList):
+    """
+    Represents a filterable DAList of incomes-type items. It can make
+    use of these attributes and methods in its items:
+
+    .source
+    .owner
+    .times_per_year
+    .value
+    .total()
+    """
+
+    def init(self, *pargs, **kwargs):
+        super().init(*pargs, **kwargs)
+        if not hasattr(self, "object_type") or self.object_type is None:
+            self.object_type = ALIncome
+
+    def sources(self) -> Set[str]:
+        """Returns a set of the unique sources in the ALIncomeList."""
+        sources = set()
+        for item in self.elements:
+            if hasattr(item, "source"):
+                sources.add(item.source)
+        return sources
+
+    def matches(
+        self, source: SourceType, exclude_source: Optional[SourceType] = None
+    ) -> "ALIncomeList":
+        """
+        Returns an ALIncomeList consisting only of elements matching the specified
+        income source, assisting in filling PDFs with predefined spaces. `source`
+        may be a list.
+        """
+        # Always make sure we're working with a set
+        satifies_sources = _source_to_callable(source, exclude_source)
+        # Construct the filtered list
+        return ALIncomeList(
+            elements=[item for item in self.elements if satifies_sources(item.source)],
+            object_type=self.object_type,
+        )
+
+    def total(
+        self,
+        times_per_year: float = 1,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+        owner: Optional[str] = None,
+    ) -> Decimal:
+        """
+        Returns the total periodic value in the list, gathering the list items
+        if necessary. You can optionally filter by `source`. `source` can be a
+        string or a list. You can also filter by one `owner`.
+
+        To calculate `.total()` correctly, all items must have a `.total()` and
+        it should be a positive value. Job-type incomes should automatically
+        exclude deductions.
+        """
+        self._trigger_gather()
+        result: Decimal = Decimal(0)
+        if times_per_year == 0:
+            return result
+        satisfies_sources = _source_to_callable(source, exclude_source)
+        for item in self.elements:
+            if (source is None and exclude_source is None) or (
+                hasattr(item, "source") and satisfies_sources(item.source)
+            ):
+                if owner is None:  # if the user doesn't care who the owner is
+                    result += Decimal(item.total(times_per_year=times_per_year))
+                else:
+                    if (
+                        not (isinstance(owner, DAEmpty))
+                        and hasattr(item, "owner")
+                        and item.owner == owner
+                    ):
+                        result += Decimal(item.total(times_per_year=times_per_year))
+        return result
+
+    def move_checks_to_list(
+        self,
+        selected_types: Optional[DADict] = None,
+        selected_terms: Optional[Mapping] = None,
+    ):
+        """Gives a 'gather by checklist' option.
+        If no selected_types param is passed, requires that a .selected_types
+        attribute be set by a `datatype: checkboxes` fields
+        If "other" is in the selected_types, the source will not be set directly
+
+        Sets the attribute "moved" to true, doesn't set gathered, because this isn't
+        idempotent, so trying to also gather all info about the checks in the list doesn't
+        work well.
+        """
+        if selected_types is None:
+            selected_types = self.selected_types
+        if not selected_terms:
+            selected_terms = {}
+        self.elements.clear()
+        for source in selected_types.true_values(insertion_order=True):
+            self.appendObject(
+                source=source, display_name=selected_terms.get(source, source)
+            )
+        self.moved = True
+
+
+class ALJob(ALIncome):
+    """
+    Represents a single job that may be hourly or pay-period based.
+
+    The job can have a net and gross income figure, but it does not represent
+    individual items like wages, tips or deductions that may appear on a paycheck--the
+    user must enter the total amount for "net" and "gross" income for a given period.
+
+    Can be stored in an ALJobList.
+
+    Attributes:
+    .value {float | Decimal} A number representing an amount of money accumulated during
+        the `times_per_year` of this income.
+    .times_per_year {float} Represents a number of the annual frequency of
+        the value. E.g. 12 for a monthly value.
+    .is_hourly {bool} (Optional): Whether the gross total should be calculated based on hours
+        worked per week
+    .hours_per_period {float} (Optional) The number of hours during the annual
+        frequency of this job. E.g. if the annual frequency is 52 (weekly), the
+        hours per week might be 50. That is, 50 hours per week.
+    .deduction {float} (Optional) The amount of money deducted from the total value each period.
+        If this job is hourly, deduction is still from each period, not each hour. Used to
+        calculate the net income in `net_income()`.
+    .employer {Individual} (Optional) A docassemble Individual object, employer.address is the address
+        and employer.phone is the phone
+    """
+
+    def init(self, *pargs, **kwargs):
+        super().init(*pargs, **kwargs)
+        # if not hasattr(self, "source") or self.source is None:
+        #    self.source = "job"
+        if not hasattr(self, "employer"):
+            if hasattr(self, "employer_type"):
+                self.initializeAttribute("employer", self.employer_type)
+            else:
+                self.initializeAttribute("employer", Individual)
+
+    def gross_total(self, times_per_year: float = 1) -> Decimal:
+        """
+        Same as ALIncome total. Returns the income over the specified times_per_year,
+        representing the `.value` attribute of the item.
+
+        `times_per_year` is some denominator of a year. E.g. to express a weekly
+        period, use 52. The default is 1 (a year).
+        """
+        return self.total(times_per_year=times_per_year)
+
+    def deductions(self, times_per_year: float = 1) -> Decimal:
+        """
+        Returns the total deductions from someone's pay over the specificed times_per_year
+        (not per hour if hourly).
+
+        `times_per_year` is some denominator of a year. E.g. to express a weekly
+        period, use 52. The default is 1 (a year).
+        """
+        deduction = _currency_float_to_decimal(self.deduction)
+        return (deduction * Decimal(self.times_per_year)) / Decimal(times_per_year)
+
+    def net_total(self, times_per_year: float = 1) -> Decimal:
+        """
+        Returns the net income over a time period, found using
+        `self.value` and `self.deduction`.
+
+        `times_per_year` is some denominator of a year. E.g, to express a weekly
+        period, use 52. The default is 1 (a year).
+
+        `self.deduction` is the amount deducted from one's pay over a period (not
+        per hour if hourly).
+
+        This will force the gathering of the ALJob's `.value` and `.deduction` attributes.
+        """
+        return self.total(times_per_year=times_per_year) - self.deductions(
+            times_per_year=times_per_year
+        )
+
+    def employer_name_address_phone(self) -> str:
+        """
+        Returns name, address and phone number of employer as a string. Forces
+        gathering the `.employer`, `.employer_address`, and `.employer_phone`
+        attributes.
+        """
+        if self.employer.address.address and self.employer.phone:
+            return (
+                f"{self.employer.name}: {self.employer.address}, {self.employer.phone}"
+            )
+        if self.employer.address.address:
+            return f"{self.employer.name}: {self.employer.address}"
+        if self.employer.phone:
+            return f"{self.employer.name}: {self.employer.phone}"
+        return f"{self.employer.name}"
+
+    def normalized_hours(self, times_per_year: float = 1) -> float:
+        """
+        Returns the normalized number of hours worked in a given times_per_year,
+        based on the self.hours_per_period and self.times_per_year attributes.
+
+        For example, if the person works 10 hours a week, it will return
+        520 when the times_per_year parameter is 1.
+
+        `times_per_year` is some denominator of a year. E.g, to express a weekly
+        period, use 52. The default is 1 (a year).
+
+        This will force the gathering of the attributes `.hours_per_period` and
+        `.times_per_year`
+        """
+        return (float(self.hours_per_period) * int(self.times_per_year)) / float(
+            times_per_year
+        )
+
+
+class ALJobList(ALIncomeList):
+    """
+    Represents a list of ALJobs. Adds the `.gross_total()` and
+    `.net_total()` methods to the ALIncomeList class. It's a more common
+    way of reporting income than ALItemizedJobList.
+    """
+
+    def init(self, *pargs, **kwargs):
+        super().init(*pargs, **kwargs)
+        self.object_type = ALJob
+
+    def total(
+        self,
+        times_per_year: float = 1,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+        owner: Optional[str] = None,
+    ) -> Decimal:
+        """
+        Returns the sum of the gross incomes of its ALJobs divided by the time
+        times_per_year. You can filter the jobs by `source`. `source` can be a
+        string or a list.
+
+        `times_per_year` is some denominator of a year. E.g, to express a weekly
+        period, use 52. The default is 1 (a year).
+        """
+        return self.gross_total(
+            times_per_year=times_per_year, source=source, exclude_source=exclude_source
+        )
+
+    def gross_total(
+        self,
+        times_per_year: float = 1,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+    ) -> Decimal:
+        """
+        Returns the sum of the gross incomes of its ALJobs divided by the time
+        times_per_year. You can filter the jobs by `source`. `source` can be a
+        string or a list.
+
+        `times_per_year` is some denominator of a year. E.g, to express a weekly
+        period, use 52. The default is 1 (a year).
+        """
+        self._trigger_gather()
+        result: Decimal = Decimal(0)
+        if times_per_year == 0:
+            return result
+        satisfies_sources = _source_to_callable(source, exclude_source)
+        for job in self.elements:
+            if satisfies_sources(job.source):
+                result += Decimal(job.gross_total(times_per_year=times_per_year))
+        return result
+
+    def net_total(
+        self,
+        times_per_year: float = 1,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+    ) -> Decimal:
+        """
+        Returns the sum of the net incomes of its ALJobs divided by the time
+        times_per_year. You can filter the jobs by `source`. `source` can be a
+        string or a list. Leaving out `source` will use all sources.
+
+        If the job is hourly, the `net_total()` may not be comparable to the
+        `gross_total()`.
+
+        `times_per_year` is some denominator of a year. E.g, to express a weekly
+        period, use 52. The default is 1 (a year).
+        """
+        self._trigger_gather()
+        result: Decimal = Decimal(0)
+        if times_per_year == 0:
+            return result
+        satisfies_sources = _source_to_callable(source, exclude_source)
+        for job in self.elements:
+            if satisfies_sources(job.source):
+                result += Decimal(job.net_total(times_per_year=times_per_year))
+        return result
+
+    def deductions(
+        self,
+        times_per_year: float = 1,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+    ) -> Decimal:
+        """
+        Returns the sum of the deductions of its ALJobs divided by the time
+        times_per_year. You can filter the jobs by `source`. Leaving out `source`
+        will use all sources.
+        """
+        self._trigger_gather()
+        result: Decimal = Decimal(0)
+        if times_per_year == 0:
+            return result
+        satisfies_sources = _source_to_callable(source, exclude_source)
+        for job in self.elements:
+            if satisfies_sources(job.source):
+                result += Decimal(job.deductions(times_per_year=times_per_year))
+        return result
+
+
+class ALExpenseList(ALIncomeList):
+    """
+    A list of expenses
+
+    * each element has a:
+        * value
+        * source
+        * display name
+    """
+
+    def init(self, *pargs, **kwargs):
+        super().init(*pargs, **kwargs)
+        self.object_type = ALExpense
+
+
+class ALAsset(ALIncome):
+    """
+    An ALAsset represents an asset that has a market value, an optional income
+    that the asset earns, and an optional balance which may be helpful if the
+    asset represents a financial account rather than a physical asset.
+
+    Can be stored in an ALAssetList.
+
+    Attributes:
+     .market_value {float | Decimal} Market value of the asset.
+    .balance {float | Decimal } Current balance of the account, e.g., like
+        the balance in a checking account, but could also represent a loan
+        amount.
+    .value {float | Decimal} (Optional) Represents the income the asset earns
+        for a given `times_per_year`, such as interest earned in a checking
+        account. If not defined, the income will be set to 0, to simplify
+        representing the many common assets that do not earn any income.
+    .times_per_year {float} (Optional) Number of times per year the asset
+        earns the income listed in the `value` attribute.
+    .owner {str} (Optional) Full name of the asset owner as a single string.
+    .source {str} (Optional) The "source" of the asset, like "vase".
+    """
+
+    def total(self, times_per_year: float = 1) -> Decimal:
+        """
+        Returns the .value attribute divided by the times per year you want to calculate. The value defaults to 0.
+
+        `times_per_year` is some denominator of a year. E.g, to express a weekly period, use 52. The default is 1 (a year).
+
+        Args:
+            times_per_year (float, optional): The number of times per year to calculate. Defaults to 1.
+
+        Returns:
+            Decimal: The .value attribute divided by the times per year.
+        """
+        if not hasattr(self, "value") or self.value == "":
+            return Decimal(0)
+        else:
+            return super(ALAsset, self).total(times_per_year=times_per_year)
+
+    def equity(self, loan_attribute="balance") -> Decimal:
+        """
+        Returns the total equity in the asset (e.g., market value minus balance).
+
+        Args:
+            loan_attribute (str, optional): The attribute of the asset to use as the loan value. Defaults to "balance".
+
+        Returns:
+            Decimal: The total equity in the asset.
+        """
+        if getattr(self, loan_attribute, None) is None:
+            return Decimal(self.market_value)
+        return Decimal(self.market_value) - Decimal(getattr(self, loan_attribute))
+
+
+class ALAssetList(ALIncomeList):
+    """
+    A list of ALAssets. The `total()` of the list will be the total income
+    earned, which may not be what you want for a list of assets. To get the
+    total value of all assets, use the `market_value()` method.
+
+    Attributes:
+        market_value (float | Decimal): Market value of the asset.
+        balance (float | Decimal): Current balance of the account, e.g., like
+            the balance in a checking account, but could also represent a loan
+            amount.
+        value (float | Decimal, optional): Represents the income the asset earns
+            for a given `times_per_year`, such as interest earned in a checking
+            account. If not defined, the income will be set to 0, to simplify
+            representing the many common assets that do not earn any income.
+        times_per_year (float, optional): Number of times per year the asset
+            earns the income listed in the `value` attribute.
+        owner (str, optional): Full name of the asset owner as a single string.
+        source (str, optional): The "source" of the asset, like "vase".
+    """
+
+    def init(self, *pargs, **kwargs):
+        super().init(*pargs, **kwargs)
+        self.object_type = ALAsset
+
+    def market_value(
+        self,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+    ) -> Decimal:
+        """
+        Returns the total `.market_value` of assets in the list.
+
+        You can filter the assets by `source`. `source` can be a string or a list.
+
+        Args:
+            source (Optional[SourceType]): The source of the assets to include in the calculation.
+                If None, all sources are included. Can be a string or a list.
+            exclude_source (Optional[SourceType]): The source of the assets to exclude from the calculation.
+                If None, no sources are excluded.
+
+        Returns:
+            Decimal: The total market value of the assets.
+        """
+        result = Decimal(0)
+        satisfies_sources = _source_to_callable(source, exclude_source)
+        for asset in self.elements:
+            if (source is None and exclude_source is None) or (
+                satisfies_sources(asset.source)
+            ):
+                result += _currency_float_to_decimal(asset.market_value)
+        return result
+
+    def balance(
+        self,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+    ) -> Decimal:
+        """
+        Returns the total `.balance` of assets in the list, which typically corresponds to the available funds in a financial account.
+
+        You can filter the assets by `source`. `source` can be a string or a list.
+
+        Args:
+            source (Optional[SourceType]): The source of the assets to include in the calculation.
+                If None, all sources are included. Can be a string or a list.
+            exclude_source (Optional[SourceType]): The source of the assets to exclude from the calculation.
+                If None, no sources are excluded.
+
+        Returns:
+            Decimal: The total balance of the assets.
+        """
+        self._trigger_gather()
+        result = Decimal(0)
+        satisfies_sources = _source_to_callable(source, exclude_source)
+        for asset in self.elements:
+            if (source is None and exclude_source is None) or (
+                satisfies_sources(asset.source)
+            ):
+                result += _currency_float_to_decimal(asset.balance)
+        return result
+
+    def equity(
+        self,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+        loan_attribute: str = "balance",
+    ) -> Decimal:
+        """
+        Calculates and returns the total equity in the assets.
+
+        This method triggers the gathering of assets, then iterates over each asset. If a source or exclude_source is not
+        specified, or if the asset's source satisfies the source criteria, the equity of the asset is added to the total.
+
+        Args:
+            source (Optional[SourceType]): The source of the assets to include in the calculation. If None, all sources are included.
+            exclude_source (Optional[SourceType]): The source of the assets to exclude from the calculation. If None, no sources are excluded.
+            loan_attribute (str, optional): The attribute of the asset to use as the loan value. Defaults to "balance".
+
+        Returns:
+            Decimal: The total equity in the assets.
+        """
+        self._trigger_gather()
+        result = Decimal(0)
+        satisfies_sources = _source_to_callable(source, exclude_source)
+        for asset in self.elements:
+            if (source is None and exclude_source is None) or (
+                satisfies_sources(asset.source)
+            ):
+                result += asset.equity(loan_attribute=loan_attribute)
+        return result
+
+    def owners(
+        self,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+    ) -> Set[str]:
+        """
+        Returns a set of the unique owners of the assets.
+
+        You can filter the assets by `source`. `source` can be a string or a list.
+
+        Args:
+            source (Optional[SourceType]): The source of the assets to include in the calculation.
+                If None, all sources are included. Can be a string or a list.
+            exclude_source (Optional[SourceType]): The source of the assets to exclude from the calculation.
+                If None, no sources are excluded.
+
+        Returns:
+            Set[str]: A set of the unique owners of the assets.
+        """
+        owners = set()
+        if source is None and exclude_source is None:
+            for asset in self.elements:
+                if hasattr(asset, "owner"):
+                    owners.add(asset.owner)
+        else:
+            satisfies_source = _source_to_callable(source, exclude_source)
+            for asset in self.elements:
+                if (
+                    hasattr(asset, "owner")
+                    and hasattr(asset, "source")
+                    and satisfies_source(asset.source)
+                ):
+                    owners.add(asset.owner)
+        return owners
+
+
+class ALVehicle(ALAsset):
+    """Represents a vehicle as a specialized type of ALAsset.
+
+    This subclass of ALAsset adds specific attributes relevant to vehicles,
+    such as year, make, and model, and includes methods for representing
+    these attributes in a standardized format, as often required on financial
+    statement forms.
+
+    Attributes:
+        year (str): The model year of the vehicle, e.g., '2022'.
+        make (str): The make of the vehicle, e.g., 'Honda'.
+        model (str): The model of the vehicle, e.g., 'Accord'.
+        market_value (float or Decimal): Market value of the vehicle.
+        balance (float or Decimal): Balance of the loan on the vehicle.
+        value (float or Decimal, optional): Income earned by the vehicle, typically 0.
+        times_per_year (int): The frequency over which the `value` is earned annually.
+        owner (str): Full name of the vehicle owner.
+        source (str, optional): The source of the asset, defaults to 'vehicle'.
+    """
+
+    def init(self, *pargs, **kwargs):
+        super().init(*pargs, **kwargs)
+        if not hasattr(self, "source"):
+            self.source = "vehicle"
+
+    def year_make_model(self, separator: str = " / ") -> str:
+        """
+        Returns a string of the format year/make/model of the vehicle. Triggers
+        gathering those attributes.
+
+        Args:
+            separator {str} (Optional) The separator between the year, make and model.
+
+        Returns:
+            A string of the format year/make/model of the vehicle.
+        """
+        return separator.join(map(str, [self.year, self.make, self.model]))
+
+
+class ALVehicleList(ALAssetList):
+    """List of ALVehicles. Extends ALAssetList."""
+
+    def init(self, *pargs, **kwargs):
+        super().init(*pargs, **kwargs)
+        self.object_type = ALVehicle
+
+
+class ALSimpleValue(DAObject):
+    """
+    Represents a currency value. It's meant to be stored in a list. Can be an
+        item in an ALSimpleValueList.
+
+    Attributes:
+    .value {str | float } The monetary value of the item.
+    .transaction_type {str} (Optional) Can be "expense", which will give a
+        negative value to the total of the item.
+    .source {str} (Optional) The "source" of the item, like "vase".
+    """
+
+    def total(self) -> Decimal:
+        """
+        If desired, to use as a ledger, values can be signed (mixed positive and
+        negative). Setting transaction_type = 'expense' makes the value negative.
+        Use min=0 in that case.
+
+        If you use signed values, be careful when placing in an ALIncomeList
+        object. The `total()` method may return unexpected results in that case.
+        """
+        val = _currency_float_to_decimal(self.value)
+        if hasattr(self, "transaction_type"):
+            return val * Decimal(-1) if (self.transaction_type == "expense") else val
+        else:
+            return val
+
+    def __str__(self) -> str:
+        """Returns the total as a formatted string"""
+        return str(self.total())
+
+
+class ALSimpleValueList(DAList):
+    """Represents a filterable DAList of ALSimpleValues."""
+
+    def init(self, *pargs, **kwargs):
+        super().init(*pargs, **kwargs)
+        self.object_type = ALSimpleValue
+
+    def sources(self) -> Set:
+        """
+        Returns a set of the unique sources of values stored in the list.
+        """
+        sources = set()
+        for value in self.elements:
+            if hasattr(value, "source"):
+                sources.add(value.source)
+        return sources
+
+    def total(
+        self,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+    ) -> Decimal:
+        """
+        Returns the total value in the list, gathering the list items if
+        necessary. You can filter the values by `source`. `source` can be a
+        string or a list.
+        """
+        self._trigger_gather()
+        result = Decimal(0)
+        if source is None and exclude_source is None:
+            for value in self.elements:
+                result += value.total()
+        else:
+            satisfies_source = _source_to_callable(source, exclude_source)
+            for value in self.elements:
+                if satisfies_source(value.source):
+                    result += value.total()
+        return result
+
+
+class ALItemizedValue(DAObject):
+    """
+    An item in an ALItemizedValueDict (a line item like wages, tips or union dues).
+    Should be a positive number, even if it will later be subtracted from the
+    job's net total.
+
+    WARNING: This item's period-based value can't be calculated correctly
+    outside of an ALItemizedJob. Its value should only be accessed through the
+    filtering methods of the ALItemizedJob that contains it.
+
+    Attributes:
+    .value {float | Decimal} A number representing an amount of money accumulated
+        during the `times_per_year` of this item or this item's job.
+    .is_hourly {bool} Whether this particular item is calculated hourly.
+    .times_per_year { float} A denominator of a year representing the annual
+         frequency of the job. E.g. 12 for monthly.
+    .exists {bool} (Optional) Allows an interview author to pre-define some common
+        descriptors, like "wages" or "union dues" without requiring the user to
+        provide a value for each item.
+
+        If the ".exists" attribute is False or undefined, the item will not be used
+        when calculating totals.
+    """
+
+    def income_fields(self, use_exists=True) -> List[Dict[str, Any]]:
+        """
+        Returns a YAML structure representing the list of fields for an itemized value,
+        to be passed to a `code` attribute of a question's fields
+        """
+        if use_exists:
+            return [
+                {
+                    "label": self.display_name,
+                    "field": self.attr_name("exists"),
+                    "datatype": "yesno",
+                },
+                {
+                    "label": word("Amount"),
+                    "field": self.attr_name("value"),
+                    "show if": self.attr_name("exists"),
+                    "datatype": "currency",
+                    "min": 0,
+                },
+            ]
+        else:
+            return [
+                {
+                    "label": self.display_name,
+                    "field": self.attr_name("value"),
+                    "datatype": "currency",
+                    "min": 0,
+                },
+            ]
+
+    def total(self) -> Decimal:
+        # If an item's value doesn't exist, use a value of 0
+        # TODO: is this behavior correct, or should it force gathering the value?
+        # What does a no-value item in the list represent?
+        if not hasattr(self, "value") or hasattr(self, "exists") and not self.exists:
+            return Decimal(0)
+
+        return _currency_float_to_decimal(self.value)
+
+    def __str__(self) -> str:
+        """Returns a string of the value of the item with two decimal places."""
+        currency_str = "{:.2f}".format(self.value)
+        return currency_str
+
+    def __float__(self) -> float:
+        if hasattr(self, "exists") and not self.exists:
+            return 0.0
+        else:
+            return float(self.value)
+
+    def __int__(self) -> int:
+        return int(float(self))
+
+    def __format__(self, format_spec) -> str:
+        return f"{float(self):{format_spec}}"
+
+
+class ALItemizedValueDict(DAOrderedDict):
+    """
+    Dictionary that can contain ALItemizedValues (e.g. line items) for an
+    ALItemizedJob. E.g., wages, tips and deductions being the most common.
+
+    An ALItemizedJob will have two ALItemizedValueDicts, one for income
+    and one for deductions.
+
+    WARNING: Should only be accessed through an ALItemizedJob. Otherwise
+        you may get unexpected results.
+    """
+
+    def init(self, *pargs, **kwargs):
+        super().init(*pargs, **kwargs)
+        self.object_type = ALItemizedValue
+        if not hasattr(self, "complete_attribute"):
+            self.complete_attribute = "value"
+
+    def hook_after_gather(self) -> None:
+        """
+        Update item lists after they've been gathered or edited to remove non-existent
+        items. Will still allow the developer to set `auto_gather=False` if they
+        want without affecting this functionality.
+        See https://docassemble.org/docs/objects.html#DAList.hook_after_gather.
+
+        If a developer wants to remove these items _before_ gathering is finished,
+        they can use similar code in their question's `validation code:`
+        """
+        keys_to_delete = []
+        # During the loop, the list has to stay steady, so don't delete those items.
+        # `.elements.items()` example of preventing gathering in `validation code:`
+        for key, value in self.elements.items():
+            if hasattr(value, "exists") and value.exists is False:
+                keys_to_delete.append(key)
+        # Delete the keys
+        for key in keys_to_delete:
+            self.delitem(key)
+
+    def total(self) -> Decimal:
+        val = Decimal(0)
+        for key, value in self.elements.items():
+            if hasattr(value, "exists") and not value.exists:
+                continue
+            val += _currency_float_to_decimal(value.value)
+        return val
+
+    def __str__(self) -> str:
+        """
+        Returns a string of the dictionary's key/value pairs as two-element lists in a list.
+        E.g. '[["federal_taxes", "2500.00"], ["wages", "15.50"]]'
+        """
+        to_stringify = []
+        for key in self:
+            to_stringify.append((key, "{:.2f}".format(self[key].value)))
+        pretty = json.dumps(to_stringify, indent=2)
+        return pretty
+
+
+class ALItemizedJob(DAObject):
+    """
+    An "Itemized" job is a job which allows the user to report very specific,
+    granular details about the money that they earn in that job and any
+    deductions that they have on their paycheck. This detailed accounting of
+    money for each job is required on some financial statements, although in
+    many financial statements, just reporting gross and net income is sufficient.
+
+    For example, an ALItemizedJob can let the user report:
+    - Wages at one hourly rate
+    - Overtime at a second hourly rate
+    - Tips earned during that time period
+    - A fixed salary earned for that pay period
+    - Union Dues
+    - Insurance
+    - Taxes
+
+    If the financial statement only requires "gross" and "net" income, the
+    ALJobList has a simpler API and may be the preferred way to represent the
+    income in code.
+
+    Attributes:
+    .to_add {ALItemizedValueDict} Dict of ALItemizedValues that would be added
+        to a job's net total, like wages and tips.
+    .to_subtract {ALItemizedValueDict} Dict of ALItemizedValues that would be
+        subtracted from a net total, like union dues or insurance premiums.
+    .times_per_year {float} A denominator of a year, like 12 for monthly, that
+        represents how frequently the income is earned
+    .is_hourly {bool} (Optional) Whether the value represents a figure that the
+        user earns on an hourly basis, rather than for the full time period
+    .hours_per_period {int} (Optional) If the job is hourly, how many hours the
+        user works per period.
+    .employer {Individual} (Optional) Individual assumed to have a name and,
+        optionally, an address and phone.
+    .source {str} (Optional) The category of this item, like "public service".
+        Defaults to "job".
+
+    WARNING: Individual items in `.to_add` and `.to_subtract` should not be used
+        directly. They should only be accessed through the filtering methods of
+        this job.
+
+    Fulfills these requirements:
+    - A job can be hourly. Its wages will be calculated with that in mind.
+    - Despite an hourly job, some individual items must be calculated using the
+        job's whole period.
+    - Some items will have their own periods.
+    - In a list of jobs, a developer may need to access full time and part time
+        jobs separately.
+    - In a list of jobs, a developer may need to sum all items from one source,
+        such as tips or taxes.
+    - The developer needs access to total money coming in, total money going out,
+        and the total of money going in and money coming out.
+    - A user must be able to add their own arbitrary items.
+    """
+
+    def init(self, *pargs, **kwargs):
+        super().init(*pargs, **kwargs)
+        # if not hasattr(self, "source") or self.source is None:
+        #    self.source = "job"
+        if not hasattr(self, "employer"):
+            if hasattr(self, "employer_type"):
+                self.initializeAttribute("employer", self.employer_type)
+            else:
+                self.initializeAttribute("employer", Individual)
+        # Money coming in
+        if not hasattr(self, "to_add"):
+            self.initializeAttribute("to_add", ALItemizedValueDict)
+        # Money being taken out
+        if not hasattr(self, "to_subtract"):
+            self.initializeAttribute("to_subtract", ALItemizedValueDict)
+
+    def _item_value_per_times_per_year(
+        self, item: ALItemizedValue, times_per_year: float = 1
+    ) -> Decimal:
+        """
+        Given an ALItemizedValue and a times_per_year, returns the value
+        accumulated by the item for that `times_per_year`, applying the
+        attributes of the top-level ALItemizedJob, such as `times_per_year` and
+        `is_hourly` as a default, and otherwise applying the attributes of the
+        ALItemizedValue.
+
+        `times_per_year` is some denominator of a year. E.g, to express a weekly
+        period, use 52. The default is 1 (a year).
+
+        Args:
+        arg item {ALItemizedValue} Object containing the value and other props
+            for an "in" or "out" ALItemizedJob item.
+        kwarg: times_per_year {float} (Optional) Number of times per year you
+            want to calculate. E.g, to express a weekly period, use 52. Default is 1.
+        """
+        if times_per_year == 0:
+            return Decimal(0)
+
+        # If an item has its own period, use that
+        # Otherwise, default to the parent times_per_year
+        if hasattr(item, "times_per_year") and item.times_per_year:
+            frequency_to_use = item.times_per_year
+        else:
+            frequency_to_use = self.times_per_year
+
+        # Both the job and the item itself need to be hourly to be
+        # calculated as hourly
+        is_hourly = self.is_hourly and hasattr(item, "is_hourly") and item.is_hourly
+        value = item.total()
+
+        # Use the appropriate calculation
+        if is_hourly:
+            # NOTE: fixes a bug that was present < 0.8.2
+            try:
+                hours_per_period = Decimal(self.hours_per_period)
+            except:
+                log(
+                    word(
+                        "Your hours per period need to be just a single number, without words"
+                    ),
+                    "danger",
+                )
+                delattr(self, "hours_per_period")
+                self.hours_per_period  # Will cause another exception
+
+            return (
+                value * Decimal(hours_per_period) * Decimal(frequency_to_use)
+            ) / Decimal(times_per_year)
+        else:
+            return (value * Decimal(frequency_to_use)) / Decimal(times_per_year)
+
+    def total(
+        self,
+        times_per_year: float = 1,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+    ) -> Decimal:
+        """
+        Alias for ALItemizedJob.gross_total to integrate with ALIncomeList math.
+        """
+        return self.gross_total(
+            times_per_year=times_per_year, source=source, exclude_source=exclude_source
+        )
+
+    def gross_total(
+        self,
+        times_per_year: float = 1,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+    ) -> Decimal:
+        """
+        Returns the sum of positive values (payments) for a given times_per_year.
+        You can filter the items by `source`. `source` can be a string or a list.
+        If you use sources from deductions, they will be ignored.
+
+        Args:
+        kwarg: times_per_year {float} (Optional) Number of times per year you
+            want to calculate. E.g, to express a weekly period, use 52. Default is 1.
+        kwarg: source {str | [str]} (Optional) Source or list of sources of desired
+            item(s).
+        """
+        # self.to_add._trigger_gather()
+        total = Decimal(0)
+        if times_per_year == 0:
+            return total
+        # Add up all money coming in from a source
+        satisfies_sources = _source_to_callable(source, exclude_source)
+        for key, value in self.to_add.elements.items():
+            if satisfies_sources(key):
+                total += self._item_value_per_times_per_year(
+                    value, times_per_year=times_per_year
+                )
+        return total
+
+    def deduction_total(
+        self,
+        times_per_year: float = 1,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+    ) -> Decimal:
+        """
+        Returns the sum of money going out (normally, deductions like union
+        dues) divided by a pay times_per_year as a positive value. You can
+        filter the items by `source`. `source` can be a string or a list.
+
+        Args:
+        kwarg: times_per_year {float} (Optional) Number of times per year you
+            want to calculate. E.g, to express a weekly period, use 52. Default is 1.
+        kwarg: source {str | List[str]} (Optional) Source or list of sources of desired
+            item(s).
+        """
+        # self.to_subtract._trigger_gather()
+        total = Decimal(0)
+        if times_per_year == 0:
+            return total
+        # Make sure we're always working with a list of sources (names?)
+        # Add up all money coming in from a source
+        satisfies_sources = _source_to_callable(source, exclude_source)
+        for key, value in self.to_subtract.elements.items():
+            if satisfies_sources(key):
+                total += self._item_value_per_times_per_year(
+                    value, times_per_year=times_per_year
+                )
+        return total
+
+    def net_total(
+        self,
+        times_per_year: float = 1,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+    ) -> Decimal:
+        """
+        Returns the net (gross minus deductions) value of the job divided by
+        `times_per_year`. You can filter the items by `source`. `source` can be a
+        string or a list. E.g. "full time" or ["full time", "union dues"]
+
+        Args:
+        kwarg: times_per_year {float} (Optional) Number of times per year you
+            want to calculate. E.g, to express a weekly period, use 52. Default is 1.
+        kwarg: source {str | List[str]} (Optional) Source or list of sources of desired
+            item(s).
+        """
+        # self.to_add._trigger_gather()
+        # self.to_subtract._trigger_gather()
+        return self.gross_total(
+            times_per_year=times_per_year, source=source, exclude_source=exclude_source
+        ) - self.deduction_total(
+            times_per_year=times_per_year, source=source, exclude_source=exclude_source
+        )
+
+    def employer_name_address_phone(self) -> str:
+        """
+        Returns concatenation of employer name and, if they exist, employer
+        address and phone number.
+        """
+        info_list = []
+        has_address = (
+            hasattr(self.employer.address, "address") and self.employer.address.address
+        )
+        has_number = (
+            hasattr(self.employer, "phone_number") and self.employer.phone_number
+        )
+        # Create a list so we can take advantage of `comma_list` instead
+        # of doing further fiddly list manipulation
+        if has_address:
+            info_list.append(self.employer.address.on_one_line())
+        if has_number:
+            info_list.append(self.employer.phone_number)
+        # If either exist, add a colon and the appropriate strings
+        if has_address or has_number:
+            return (
+                f"{ self.employer.name.full(middle='full') }: {comma_list( info_list )}"
+            )
+        return self.employer.name.full(middle="full")
+
+    def normalized_hours(self, times_per_year: float = 1) -> float:
+        """
+        Returns the normalized number of hours worked in a given times_per_year,
+        based on the self.hours_per_period and self.times_per_year attributes.
+
+        For example, if the person works 10 hours a week, it will return
+        520 when the times_per_year parameter is 1.
+        """
+        return (float(self.hours_per_period) * float(self.times_per_year)) / float(
+            times_per_year
+        )
+
+
+class ALItemizedJobList(DAList):
+    """
+    Represents a list of ALItemizedJobs that can have both payments and money
+        out. This is a less common way of reporting income.
+    """
+
+    def init(self, *pargs, **kwargs):
+        super().init(*pargs, **kwargs)
+        if not hasattr(self, "source") or self.source is None:
+            self.source = "jobs"
+        if not hasattr(self, "object_type") or self.object_type is None:
+            self.object_type = ALItemizedJob
+
+    def sources(self, which_side: Optional[str] = None) -> Set[str]:
+        """Returns a set of the unique sources in all of the jobs.
+        By default gets from both sides, if which_side is "deductions", only gets from deductions.
+        """
+        sources = set()
+        if not which_side:
+            which_side = "all"
+        for job in self.elements:
+            if which_side == "all" or which_side == "incomes":
+                sources.update(job.to_add.keys())
+            if which_side == "all" or which_side == "deductions":
+                sources.update(job.to_subtract.keys())
+        return sources
+
+    def total(
+        self,
+        times_per_year: float = 1,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+    ) -> Decimal:
+        """
+        Alias for ALItemizedJobList.gross_total to integrate with
+        ALIncomeList math.
+        """
+        return self.gross_total(
+            times_per_year=times_per_year, source=source, exclude_source=exclude_source
+        )
+
+    def gross_total(
+        self,
+        times_per_year: float = 1,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+    ) -> Decimal:
+        """
+        Returns the sum of the gross incomes of the list's jobs divided by the
+        times_per_year. You can filter the items by `source`. `source` can be a
+        string or a list.
+
+        Args:
+        kwarg: source {str | [str]} - (Optional) Source or list of sources of
+            desired job items to sum from every itemized job.
+            E.g. ['tips', 'commissions']
+        kwarg: times_per_year {float} (Optional) Number of times per year you
+            want to calculate. E.g, to express a weekly period, use 52. Default is 1.
+        """
+        self._trigger_gather()
+        total = Decimal(0)
+        if times_per_year == 0:
+            return total
+        # Add all job gross totals from particular sources
+        for job in self.elements:
+            total += job.gross_total(
+                times_per_year=times_per_year,
+                source=source,
+                exclude_source=exclude_source,
+            )
+        return total
+
+    def deduction_total(
+        self,
+        times_per_year: float = 1,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+    ) -> Decimal:
+        """
+        Returns the sum of the deductions of the list's jobs divided by the
+        times_per_year. You can filter the items by `source`. `source` can be a
+        string or a list.
+
+        Args:
+        kwarg: source {str | [str]} - (Optional) Source or list of sources of
+            desired job items to sum from every itemized job.
+            E.g. ['taxes', 'dues']
+        kwarg: times_per_year {float} (Optional) Number of times per year you
+            want to calculate. E.g, to express a weekly period, use 52. Default is 1.
+        """
+        self._trigger_gather()
+        total = Decimal(0)
+        if times_per_year == 0:
+            return total
+        # Add all the money going out for all jobs
+        for job in self.elements:
+            total += job.deduction_total(
+                times_per_year=times_per_year,
+                source=source,
+                exclude_source=exclude_source,
+            )
+        return total
+
+    def net_total(
+        self,
+        times_per_year: float = 1,
+        source: Optional[SourceType] = None,
+        exclude_source: Optional[SourceType] = None,
+    ) -> Decimal:
+        """
+        Returns the net of the list's jobs (money in minus money out) divided by
+        the times_per_year. You can filter the items by `source`. `source` can be a
+        string or a list.
+
+        Args:
+        kwarg: source {str | List[str]} - (Optional) Source or list of sources of
+            desired job items to sum from every itemized job.
+            E.g. ['tips', 'taxes']
+        kwarg: times_per_year {float} (Optional) Number of times per year you
+            want to calculate. E.g, to express a weekly period, use 52. Default is 1.
+        """
+        return self.gross_total(
+            times_per_year=times_per_year, source=source
+        ) - self.deduction_total(
+            times_per_year=times_per_year, source=source, exclude_source=exclude_source
+        )

--- a/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
+++ b/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
@@ -13,9 +13,9 @@ code: |
 ---
 objects:
   - users: ALPeopleList.using(ask_number=True,target_number=1)
-  - public_benefits: ALIncomeList.using(complete_attribute='value')
+  - public_benefits: ALIncomeList.using(complete_attribute='complete')
   - jobs: ALItemizedJobList.using(complete_attribute="complete", ask_number=True)
-  - other_incomes: ALIncomeList.using(complete_attribute='value')
+  - other_incomes: ALIncomeList.using(complete_attribute='complete')
   - expenses: ALExpenseList.using(complete_attribute='complete')
   - bank_assets: ALAssetList.using(complete_attribute='value')
   - vehicles: ALVehicleList.using(complete_attribute='complete')
@@ -275,7 +275,7 @@ data: !!omap
   - ssi: "Supplemental Security Income (SSI)"
   - dr dynasaur: "Dr. Dynasaur"
   - medicaid: "Medicaid"
-  - other benefit: "Other"
+  - other: "Other"
 ---
 id: are there public benefits
 #public_benefits
@@ -307,16 +307,16 @@ question: |
   Tell us about your ${ ordinal(i) } benefits
 #subquestion: |
   #% if i > 1:
-  #You have already told us about your benefits from ${ comma_and_list([income.source for public_benefits in x.complete_elements()]) }.
+  #You have already told us about your benefits from ${ comma_and_list([income.source_display for public_benefits in x.complete_elements()]) }.
   #% elif i > 0:
-  #You have already told us about your benefits from ${ comma_and_list([income.source for public_benefits in x.complete_elements()]) }.
+  #You have already told us about your benefits from ${ comma_and_list([income.source_display for public_benefits in x.complete_elements()]) }.
   #% endif
 fields:
   - Source of income: public_benefits[i].source
     input type: dropdown
     code: |
       benefits_ordered
-  - What type of income?: public_benefits[i].source
+  - What type of income?: public_benefits[i].source_other
     show if:
       variable: public_benefits[i].source
       is: other
@@ -334,6 +334,10 @@ data: !!omap
   - unemployment income: "Unemployment benefits"
   - child support income: "Child support"
   - other: "Other"
+---
+generic object: ALIncomeList
+code: |
+  x[i].display_name = x.terms_ordered.get(x[i].source, x[i].source)
 ---
 variable name: help_text
 data: !!omap
@@ -369,23 +373,36 @@ fields:
   - note: |
       **Other kinds of income could include:** disability insurance?, social security?, workers compensation, veteran's income, rental income, interest income, spousal maintenance (alimony), retirement income and annuities.
 ---
+generic object: ALIncome
+code: |
+  if x.source == "other":
+    x.source_display = x.source_other
+  else:
+    x.source_display = x.display_name
+---
+generic object: ALExpense
+code: |
+  if x.source == "other":
+    x.source_display = x.source_other
+  else:
+    x.source_display = x.display_name
+---
 id: other income info for list
 #generic object: ALIncomeList
 question: |
   Tell us about your ${ ordinal(i) } income
 subquestion: |
   % if i > 1:
-  You have already told us about your incomes from ${ comma_and_list([income.source for income in x.complete_elements()]) }.
+  You have already told us about your incomes from ${ comma_and_list([income.source_display for income in other_incomes.complete_elements()]) }.
   % elif i > 0:
-  You have already told us about your income from ${ comma_and_list([income.source for income in x.complete_elements()]) }.
+  You have already told us about your income from ${ comma_and_list([income.source_display for income in other_incomes.complete_elements()]) }.
   % endif
 fields:
   - Source of income: other_incomes[i].source
     input type: dropdown
     code: |
       other_incomes_ordered
-    default: other
-  - What type of income?: other_incomes[i].source
+  - What type of income?: other_incomes[i].source_other
     show if:
       variable: other_incomes[i].source
       is: other
@@ -648,7 +665,7 @@ table: jobs.table
 rows: jobs
 columns:
   - Job title: |
-      row_item.source
+      row_item.source_display
   - Employer: |
       row_item.employer.name if hasattr(row_item.employer.name, "first") else ""
   - Monthly Gross Income: |
@@ -910,11 +927,28 @@ fields:
 
       **"Other insurance" you might enter:** dental, vision, home, rental, life insurance and more.
 ---
+generic object: ALIncome
+code: |
+  x.check_for_other
+  x.value
+  x.source_display
+  x.complete = True
+---
+code: |
+  if not hasattr(public_benefits[i],'source') and i < len(public_benefits.selected_types.true_values()):
+    public_benefits[i].source = 'other'
+  public_benefits[i].check_for_other = True
+---
+code: |
+  if not hasattr(other_incomes[i],'source') and i < len(other_incomes.selected_types.true_values()):
+    other_incomes[i].source = 'other'
+  other_incomes[i].check_for_other = True
+---
 generic object: ALExpense
 code: |
   x.check_for_other
   x.value
-  x.set_source_other
+  x.source_display
   x.complete = True
 ---
 generic object: ALExpense
@@ -922,12 +956,6 @@ code: |
   if not hasattr(expenses[i],'source') and i < len(expenses.selected_types.true_values()):
     expenses[i].source = 'other'
   expenses[i].check_for_other = True
----
-generic object: ALExpense
-code: |
-  if hasattr(x,'source_other'):
-    x.source = x.source_other
-  x.set_source_other = True
 ---
 generic object: ALExpenseList
 need:
@@ -944,7 +972,7 @@ subquestion: |
 fields:
   - Amount: x[i].value
     datatype: currency
-#  - Other (explain): x[i].source
+#  - Other (explain): x[i].source_other
 #    show if:
 #      variable: x[i].source
 #      is: other
@@ -1025,7 +1053,7 @@ generic object: ALVehicleList
 code: |
   x[i].check_for_other
   x[i].market_value
-  x[i].set_source_other
+  x[i].source_display
   x[i].complete = True
 ---
 generic object: ALVehicle
@@ -1033,13 +1061,6 @@ code: |
   if x.source == 'vehicle' and i < len(vehicles.selected_types.true_values()):
     x.source = 'other'
   x.check_for_other = True
----
-generic object: ALVehicle
-code: |
-  if hasattr(x,'source_other'):
-    x.source = x.source_other
-  x.set_source_other = True
----
 ---
 id: info for each vehicle
 question: |
@@ -1099,18 +1120,13 @@ fields:
 code: |
   real_estate[i].check_for_other
   real_estate[i].market_value
-  real_estate[i].set_source_other
+  real_estate[i].source_display
   real_estate[i].complete = True
 ---
 code: |
   if not hasattr(real_estate[i],'source') and i < len(real_estate.selected_types.true_values()):
     real_estate[i].source = 'other'
   real_estate[i].check_for_other = True
----
-code: |
-  if hasattr(real_estate[i],'source_other'):
-    real_estate[i].source = real_estate[i].source_other
-  real_estate[i].set_source_other = True
 ---
 id: info for each real estate
 question: |
@@ -1166,7 +1182,7 @@ fields:
 code: |
   other_assets[i].check_for_other
   other_assets[i].market_value
-  other_assets[i].set_source_other
+  other_assets[i].source_display
   other_assets[i].complete = True
 ---
 code: |
@@ -1174,16 +1190,10 @@ code: |
     other_assets[i].source = 'other'
   other_assets[i].check_for_other = True
 ---
-code: |
-  if hasattr(other_assets[i],'source_other'):
-    other_assets[i].source = other_assets[i].source_other
-  other_assets[i].set_source_other = True
----
 # workaround to get the display names to show and to be able to add a benefit in review screen
 id: public benefits display names
-generic object: ALIncome
 code: |
-  x.display_name = public_benefits.terms_ordered.get(x.source, x.source)
+  public_benefits.display_name = public_benefits.terms_ordered.get(x.source, x.source)
 ---
 id: real estate display names
 #generic object: ALAsset
@@ -1345,6 +1355,15 @@ code: |
   other_incomes.there_is_another = False
   bank_assets.there_is_another = False
 ---
+question: Do you want to add any more public benefits?
+yesno: public_benefits.there_is_another
+---
+question: Do you want to add any more incomes?
+yesno: other_incomes.there_is_another
+---
+question: Do you want to add any more bank assets?
+yesno: bank_assets.there_is_another
+---
 question: Do you want to add any more expenses?
 yesno: expenses.there_is_another
 ---
@@ -1471,7 +1490,7 @@ review:
       
       % for item in expenses:
       % if item.display_name == "Other expenses":
-      - ${ item.source.lower() }
+      - ${ item.source_display.lower() }
       % else:
       - ${ item.display_name.lower() }
       % endif
@@ -1499,7 +1518,7 @@ review:
       **Real estate**
 
       % for item in real_estate.complete_elements():
-      * ${ item.display_name }       
+      * ${ item.source_display }       
       % endfor
       % if not real_estate.there_are_any:
       - None
@@ -1525,11 +1544,7 @@ review:
       **Other assets**
 
       % for item in other_assets.complete_elements():
-      % if item.source == "other":
-        - ${ item.source_other }
-      % else:
-        - ${ item.source }
-      % endif
+        - ${ item.source_display }
       % endfor
 
       % if not other_assets.there_are_any:
@@ -1610,7 +1625,7 @@ table: public_benefits.table
 rows: public_benefits
 columns:
   - Source: |
-      row_item.display_name if defined("row_item.source") else ""
+      row_item.source_display if defined("row_item.source") else ""
   - Amount: |
       currency(row_item.value) if defined("row_item.value") else ""
 edit:
@@ -1631,7 +1646,7 @@ table: other_incomes.table
 rows: other_incomes
 columns:
   - Source: |
-      row_item.source if defined("row_item.source") else ""
+      row_item.source_display if defined("row_item.source") else ""
   - Value: |
       currency(row_item.value) if defined("row_item.value") else ""
 edit:
@@ -1651,7 +1666,7 @@ table: expenses.table
 rows: expenses
 columns:
   - Type: |
-      row_item.source.lower()
+      row_item.source_display.lower()
   - Amount per month: |
       currency(row_item.total(times_per_year=12))
 edit:
@@ -1671,7 +1686,7 @@ table: bank_assets.table
 rows: bank_assets
 columns:
   - Source: |
-      row_item.source if defined("row_item.source") else ""
+      row_item.source_display if defined("row_item.source") else ""
   - Value: |
       currency(row_item.market_value) if defined("row_item.market_value") else ""
 edit:
@@ -1715,7 +1730,7 @@ table: real_estate.table
 rows: real_estate
 columns:
   - Description: |
-      row_item.display_name if defined("row_item.display_name") else ""
+      row_item.source_display if defined("row_item.source") else ""
   - Market value: |
       currency(row_item.market_value) if defined("row_item.market_value") else ""
   - Amount owed: |

--- a/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
+++ b/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
@@ -18,6 +18,9 @@ objects:
   - users: ALPeopleList.using(ask_number=True,target_number=1)
   - jobs: ALItemizedJobList.using(complete_attribute="complete", ask_number=True)
 ---
+objects:
+  - jobs[i].to_add: ALItemizedValueDict.using(complete_attribute="complete", there_are_any=True)
+---
 comment: |
   Global interview metadata
 metadata:
@@ -123,41 +126,11 @@ code: |
   public_benefits.gather()
   if public_benefits.there_are_any:
     user_qualifies_interstitial   
-    if employed:
-      if jobs.target_number == 1:
-        if not jobs[0].is_self_employed:
-          jobs[0].employer.name.first
-      if jobs.target_number == 2:
-        if not jobs[0].is_self_employed:
-          jobs[0].employer.name.first
-        if not jobs[1].is_self_employed:
-          jobs[1].employer.name.first
-      if jobs.target_number == 3:
-        if not jobs[0].is_self_employed:
-          jobs[0].employer.name.first
-        if not jobs[1].is_self_employed:
-          jobs[1].employer.name.first 
-        if not jobs[2].is_self_employed:
-          jobs[2].employer.name.first       
+    jobs.gather()
+    review_jobs    
   else:
-    if employed:
-      jobs.target_number
-      
-      if jobs.target_number == 1:
-        jobs[0].to_subtract.there_are_any = False
-      if jobs.target_number == 2:
-        jobs[0].to_subtract.there_are_any = False
-        jobs[1].to_subtract.there_are_any = False
-      if jobs.target_number == 3:
-        jobs[0].to_subtract.there_are_any = False
-        jobs[1].to_subtract.there_are_any = False
-        jobs[2].to_subtract.there_are_any = False
-      #If they say they are self-employed gather their monthly net income and set 
-      if jobs[0].is_self_employed:
-        users1_income_self_employment_monthly_amount
-      else:
-        jobs.gather()
-        review_jobs
+    jobs.gather()
+    review_jobs
     set_progress(40)
     
     other_incomes.gather()
@@ -538,6 +511,20 @@ fields:
   - Your monthly net income: users1_income_self_employment_monthly_amount
     datatype: currency
 ---
+generic object: ALItemizedJob
+code: |
+  x.source
+  if not x.is_self_employed:
+    x.employer.name.first
+  x.wages_added
+  x.to_add.gather()
+  # x.to_subtract.gather()
+  x.complete = True
+---
+generic object: ALItemizedValueDict
+code: |
+  x.complete = True
+---
 sets:
   - x.employer.name.first
 id: employer
@@ -547,6 +534,8 @@ question: |
 fields:
   - I am self-employed: x.is_self_employed
     datatype: yesno
+  - Is this a part time job: x.is_part_time
+    datatype: yesnoradio
   - Employer's name: x.employer.name.first
     show if:
       variable: x.is_self_employed
@@ -580,6 +569,16 @@ fields:
       variable: x.is_self_employed
       is: False
 ---
+generic object: ALItemizedJob
+code: |
+  if x.is_part_time:
+    x.to_add.there_are_any = True
+    x.to_add.new_item_name = "part time"
+  else:
+    x.to_add.there_are_any = True
+    x.to_add.new_item_name = "full time"
+  x.wages_added = True
+---
 #generic object: ALItemizedJob
 #code: |
 #  jobs[x]to_subtract.there_are_any = False
@@ -587,71 +586,50 @@ fields:
 id: itemized job period
 generic object: ALItemizedJob
 question: |
-  Details about the ${ x.source } job
+  Details about ${ j } compensation for your ${ jobs[i].source } job
 fields:
-  - Is this a part time job: x.is_part_time
-    datatype: yesnoradio
-  - Paid hourly or salary?: x.is_hourly
+  - Paid hourly or salary?: jobs[i].to_add[j].is_hourly
     input type: radio
     choices:
       - Hourly: True
       - Salary: False
-  - How often does ${ x.employer} pay?: x.times_per_year
+  - label: |
+      What is your hourly pay for this job?
+    field: jobs[i].to_add[j].value
+    datatype: currency
+    show if: 
+      variable: jobs[i].to_add[j].is_hourly
+      is: True
+  - label: |
+      What do you get for wages during each pay period (x.times_per_year)?
+    field: jobs[i].to_add[j].value
+    datatype: currency
+    show if: 
+      variable: jobs[i].to_add[j].is_hourly
+      is: False
+  - How often  are you paid?: jobs[i].to_add[j].times_per_year
     input type: radio
     code: |
       times_per_year_list
     datatype: integer
-  - How many hours are worked during that time?: x.hours_per_period
+  - How many hours are worked during that time?: jobs[i].to_add[j].hours_per_period
     datatype: number
-    show if: x.is_hourly
+    show if: 
+      variable: jobs[i].to_add[j].is_hourly
+      is: True
     validation messages:
       number: |
         Enter a number, like 40. If you don't know, enter your best guess.
-
+  - Does the job have other incomes, like tips, commissions or bonuses?: jobs[i].to_add.there_is_another
+    datatype: yesnoradio
 ---
-id: itemized job line items
-generic object: ALItemizedJob
-question: |
-    Enter info from your paystub for your job as a ${ x.source }
+question: Are there more types of non-wage income for your job  as a ${ x.source }?
+subquestion: |
+  You have already mentioned:
+  ${ x.to_add.true_values() }
 fields:
-    - label: |
-        % if x.is_hourly:
-        What is your hourly pay for this job?
-        % else:
-        What do you get for wages during each pay period (x.times_per_year)?
-        % endif
-      field: x.to_add['full time'].value
-      datatype: currency
-      show if:
-        code: x.is_part_time is False
-    - note: |
-        Enter the gross amount, before taxes and other things are taken out.
-      show if:
-        code: x.is_part_time is False
-    - label: |
-        % if x.is_hourly:
-        What is your hourly pay for this job?
-        % else:
-        What do you get for wages during each pay period (x.times_per_year)?
-        % endif
-      field: x.to_add['part time'].value
-      datatype: currency
-      show if:
-        code: x.is_part_time is True
-    - note: |
-        Enter the gross amount, before taxes and other things are taken out.
-      show if:
-        code: x.is_part_time is True
-    #- What is your federal tax amount?: x.to_subtract['federal_taxes'].value
-      #datatype: currency
-      #required: False
-    #- What do you pay for insurance?: x.to_subtract['insurance'].value
-      #datatype: currency
-      #required: False
-    - Does the job have other incomes, like tips, commissions or bonuses?: x.to_add.there_is_another
-      datatype: yesnoradio
-    #- Does the job have other deductions?: x.to_subtract.there_is_another
-      #datatype: yesnoradio
+  - Does the job have other incomes, like tips, commissions or bonuses?: x.to_add.there_is_another
+    datatype: yesnoradio
 ---
 id: jobs details about tips commissions bonuses
 generic object: ALItemizedJob
@@ -661,6 +639,16 @@ subquestion: |
   You have already told us about your income from **${comma_and_list( [job_items_names.get(key, key).lower() for key in x.to_add.complete_elements().keys()] )}**.
 fields:
   - What kind of additional income do you get from this job? (Examples -- Tips, commissions, bonuses): x.to_add.new_item_name
+    datatype: radio
+    choices:
+      - Tips
+      - Commissions
+      - Bonuses
+      - Other
+  - Specify: x.to_add.new_item_name
+    show if:
+      variable: x.to_add.new_item_name
+      is: "Other"
 validation code: |
   if x.to_add.new_item_name in x.to_add.complete_elements().keys():
     validation_error(f'You already told us about your <strong>{job_items_names.get(x.to_add.new_item_name, x.to_add.new_item_name) }</strong> that pays { currency( x.to_add[ x.to_add.new_item_name ].value )}. Pick a different name.')
@@ -687,7 +675,7 @@ fields:
     datatype: integer
     hide if:
       code: x.is_hourly is True
-  - How often do you get paid by ${ x.employer}?: x.to_add[i].times_per_year
+  - How often do you get paid?: x.to_add[i].times_per_year
     input type: radio
     code: |
       times_per_year_list
@@ -755,20 +743,59 @@ table: jobs.table
 rows: jobs
 columns:
   - Job title: |
-      row_item.display_name
+      row_item.source
   - Employer: |
       row_item.employer.name if hasattr(row_item.employer.name, "first") else ""
   - Monthly Gross Income: |
       currency(row_item.gross_total(times_per_year=12))
 
 edit:
-  - source
-  - employer.name.first
-  - employer.address.city
-  - times_per_year
-  - to_add.revisit
-  - to_subtract.revisit
+  - revisit
 confirm: True
+---
+generic object: ALItemizedJob
+question: Review
+fields:
+  - Job: x.source
+  - I am self-employed: x.is_self_employed
+    datatype: yesno
+  - Employer's name: x.employer.name.first
+    show if:
+      variable: x.is_self_employed
+      is: False
+  - note: |
+      ---
+
+      Employer's contact information
+    show if:
+      variable: x.is_self_employed
+      is: False
+  - Street address: x.employer.address.address
+    show if:
+      variable: x.is_self_employed
+      is: False
+  - Unit: x.employer.address.unit
+    required: False
+    show if:
+      variable: x.is_self_employed
+      is: False
+  - City: x.employer.address.city
+    show if:
+      variable: x.is_self_employed
+      is: False
+  - State: x.employer.address.state
+    show if:
+      variable: x.is_self_employed
+      is: False
+  - Zip or postal code: x.employer.address.zip
+    show if:
+      variable: x.is_self_employed
+      is: False
+under: |
+  ${ x.to_add.table }
+
+  ${ x.to_add.add_action() }  
+continue button field: x.revisit
 ---
 generic object: ALItemizedValueDict
 table: x.table

--- a/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
+++ b/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
@@ -126,11 +126,13 @@ code: |
   public_benefits.gather()
   if public_benefits.there_are_any:
     user_qualifies_interstitial   
-    jobs.gather()
-    review_jobs    
+    if employed:
+      jobs.gather()
+      review_jobs    
   else:
-    jobs.gather()
-    review_jobs
+    if employed:
+      jobs.gather()
+      review_jobs
     set_progress(40)
     
     other_incomes.gather()
@@ -583,6 +585,38 @@ code: |
 #code: |
 #  jobs[x]to_subtract.there_are_any = False
 ---
+id: other itemized job income value
+generic object: ALItemizedJob
+question: |
+  Edit your ${ job_items_names.get(i, i) } in your job as a ${ x.source }
+fields:
+  - Amount: x.to_add[i].value
+    datatype: currency
+    hide if:
+      code: x.is_hourly is True
+  - Your hourly pay rate: x.to_add[i].value
+    datatype: currency
+    show if:
+      code: x.is_hourly is True
+        
+  - How often do you get paid this amount?: x.to_add[i].times_per_year
+    input type: radio
+    code: |
+      times_per_year_list
+    datatype: integer
+    hide if:
+      code: x.is_hourly is True
+  - How often do you get paid?: x.to_add[i].times_per_year
+    input type: radio
+    code: |
+      times_per_year_list
+    datatype: integer
+    show if:
+      code: x.is_hourly is True
+  #- Do you have other additional income from this job? (Examples -- Tips, commissions, bonuses): x.to_add.there_is_another
+    #datatype: yesnoradio
+---
+if: j in ["full time","part time"]
 id: itemized job period
 generic object: ALItemizedJob
 question: |
@@ -623,6 +657,28 @@ fields:
   - Does the job have other incomes, like tips, commissions or bonuses?: jobs[i].to_add.there_is_another
     datatype: yesnoradio
 ---
+if: j not in ["full time","part time"]
+id: itemized job period
+generic object: ALItemizedJob
+question: |
+  Details about ${ j } compensation for your ${ jobs[i].source } job
+fields:
+  - label: |
+      Amount
+    field: jobs[i].to_add[j].value
+    datatype: currency
+  - How often  are you paid?: jobs[i].to_add[j].times_per_year
+    input type: radio
+    code: |
+      times_per_year_list
+    datatype: integer
+  - Does the job have other incomes, like tips, commissions or bonuses?: jobs[i].to_add.there_is_another
+    datatype: yesnoradio
+---
+code: |
+  if j not in ["full time","part time"]:
+    jobs[i].to_add[j].is_hourly = False
+---
 question: Are there more types of non-wage income for your job  as a ${ x.source }?
 subquestion: |
   You have already mentioned:
@@ -653,37 +709,6 @@ validation code: |
   if x.to_add.new_item_name in x.to_add.complete_elements().keys():
     validation_error(f'You already told us about your <strong>{job_items_names.get(x.to_add.new_item_name, x.to_add.new_item_name) }</strong> that pays { currency( x.to_add[ x.to_add.new_item_name ].value )}. Pick a different name.')
 
----
-id: other itemized job income value
-generic object: ALItemizedJob
-question: |
-  Edit your ${ job_items_names.get(i, i) } in your job as a ${ x.source }
-fields:
-  - Amount: x.to_add[i].value
-    datatype: currency
-    hide if:
-      code: x.is_hourly is True
-  - Your hourly pay rate: x.to_add[i].value
-    datatype: currency
-    show if:
-      code: x.is_hourly is True
-        
-  - How often do you get paid this amount?: x.to_add[i].times_per_year
-    input type: radio
-    code: |
-      times_per_year_list
-    datatype: integer
-    hide if:
-      code: x.is_hourly is True
-  - How often do you get paid?: x.to_add[i].times_per_year
-    input type: radio
-    code: |
-      times_per_year_list
-    datatype: integer
-    show if:
-      code: x.is_hourly is True
-  #- Do you have other additional income from this job? (Examples -- Tips, commissions, bonuses): x.to_add.there_is_another
-    #datatype: yesnoradio
 ---
 id: edit wages and other incomes from a job
 generic object: ALItemizedJob

--- a/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
+++ b/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
@@ -22,31 +22,6 @@ objects:
   - real_estate: ALAssetList.using(complete_attribute='complete')
   - other_assets: ALAssetList.using(complete_attribute='complete')
 ---
-generic object: ALIncomeList
-code: |
-  x.selected_types
-  x.move_checks_to_list(selected_terms=x.terms_ordered)
-  x.moved = True
----
-generic object: ALExpenseList
-code: |
-  x.selected_types
-  x.move_checks_to_list(selected_terms=x.terms_ordered)
-  x.moved = True
----
-generic object: ALAssetList
-code: |
-  x.selected_types
-  x.move_checks_to_list(selected_terms=x.terms_ordered)
-  x.moved = True
----
-generic object: ALVehicleList
-code: |
-  x.selected_types
-  x.move_checks_to_list(selected_terms=x.terms_ordered)
-  x.moved = True
----
----
 comment: |
   Global interview metadata
 metadata:
@@ -264,6 +239,33 @@ code: |
 
 ---
 #################################PUBLIC BENEFITS##############################
+comment: |
+  Notes on how a list is gathered
+  
+  Interview calls public_benefits.gather
+
+  Gather looks for .there_are_any
+
+  there_any_any asks for x.selected_types
+
+  if any selected types,
+   move_check_to_lists
+     This creates a number of elements in the list, and deletes 'source' if other, (which may set 'source' to the default, like 'vehicle')
+     also sets .moved for the list
+     
+  there_are_any is set to true
+
+  will then look for complete
+
+  check_for_others will set source
+
+  complete calls for attribute (value for public_benefits) for information question
+  
+  information question calls display name (with reconsider to keep it fresh)
+  
+  answering the question sets display_name fresh with new source_other with validation code
+
+  complete sets display  
 ---
 variable name: public_benefits.terms_ordered
 data: !!omap
@@ -276,6 +278,14 @@ data: !!omap
   - dr dynasaur: "Dr. Dynasaur"
   - medicaid: "Medicaid"
   - other: "Other"
+---
+generic object: ALIncomeList
+code: |
+  if x.selected_types.any_true():
+    x.move_checks_to_list(selected_terms=x.terms_ordered)
+    x.there_are_any = True
+  else:
+    x.there_are_any = False
 ---
 id: are there public benefits
 #public_benefits
@@ -293,24 +303,28 @@ fields:
     code: |
       benefits_ordered
 ---
-generic object: ALIncomeList
+generic object: ALIncome
 code: |
-  if x.selected_types.any_true():
-    x.move_checks_to_list(selected_terms=x.terms_ordered)
-    x.there_are_any = True
-  else:
-    x.there_are_any = False
+  x.check_for_other
+  x.value
+  x.complete = True
+---
+code: |
+  if not hasattr(public_benefits[i],'source') and i < len(public_benefits.selected_types.true_values()):
+    public_benefits[i].source = 'other'
+  public_benefits[i].check_for_other = True
 ---
 id: public benefits info for list
 #generic object: ALIncomeList
+reconsider: public_benefits[i].display_name
 question: |
-  Tell us about your ${ ordinal(i) } benefits
-#subquestion: |
-  #% if i > 1:
-  #You have already told us about your benefits from ${ comma_and_list([income.source_display for public_benefits in x.complete_elements()]) }.
-  #% elif i > 0:
-  #You have already told us about your benefits from ${ comma_and_list([income.source_display for public_benefits in x.complete_elements()]) }.
-  #% endif
+  Tell us about ${ public_benefits[i].display_name }.
+subquestion: |
+  % if i > 1:
+  You have already told us about your benefits from ${ comma_and_list(public_benefit.display_name for public_benefit in public_benefits.complete_elements()) }.
+  % elif i > 0:
+  You have already told us about your benefits from ${ comma_and_list(public_benefit.display_name for public_benefit in public_benefits.complete_elements()) }.
+  % endif
 fields:
   - Source of income: public_benefits[i].source
     input type: dropdown
@@ -327,22 +341,43 @@ fields:
       times_per_year_list
   - Amount of income: public_benefits[i].value
     datatype: currency
-
+validation code: |
+  if public_benefits[i].source != "other":
+    public_benefits[i].display_name = public_benefits.terms_ordered.get(public_benefits[i].source, public_benefits[i].source)
+  else:
+    public_benefits[i].display_name = public_benefits[i].source_other
 ---
-variable name: other_incomes.terms_ordered
-data: !!omap
-  - unemployment income: "Unemployment benefits"
-  - child support income: "Child support"
-  - other: "Other"
----
-generic object: ALIncomeList
 code: |
-  x[i].display_name = x.terms_ordered.get(x[i].source, x[i].source)
+  if defined('public_benefits[i].source') and public_benefits[i].source != "other":
+    public_benefits[i].display_name = public_benefits.terms_ordered.get(public_benefits[i].source, public_benefits[i].source)
+  elif defined('public_benefits[i].source') and public_benefits[i].source == "other" and defined('public_benefits[i].source_other'):
+    public_benefits[i].display_name = public_benefits[i].source_other
+  else:
+    public_benefits[i].display_name = "another benefit that provides you income"
 ---
-variable name: help_text
-data: !!omap
-  - unemployment income help: "Enter gross amount of unemployment income -- before taxes were taken out."
-  - default: " "
+question: Do you want to add any more public benefits?
+subquestion: |
+  ${ public_benefits_table }
+yesno: public_benefits.there_is_another
+---
+continue button field: public_benefits.revisit
+question: |
+  Edit public assistance
+subquestion: |
+  ${ public_benefits_table }
+
+  ${ public_benefits.add_action() }
+---
+table: public_benefits_table
+rows: public_benefits.complete_elements()
+columns:
+  - Source: |
+      row_item.display_name if defined("row_item.source") else ""
+  - Amount: |
+      currency(row_item.value) if defined("row_item.value") else ""
+edit:
+  - source
+  - value
 ---
 id: user qualifies due to benefits
 continue button field: user_qualifies_interstitial
@@ -356,6 +391,17 @@ subquestion: |
   Click Next to answer a few more questions.
 ---
 #################################OTHER INCOMES##############################
+---
+variable name: other_incomes.terms_ordered
+data: !!omap
+  - unemployment income: "Unemployment benefits"
+  - child support income: "Child support"
+  - other: "Other"
+---
+variable name: help_text
+data: !!omap
+  - unemployment income help: "Enter gross amount of unemployment income -- before taxes were taken out."
+  - default: " "
 ---
 id: are there other incomes
 #other_incomes
@@ -373,29 +419,15 @@ fields:
   - note: |
       **Other kinds of income could include:** disability insurance?, social security?, workers compensation, veteran's income, rental income, interest income, spousal maintenance (alimony), retirement income and annuities.
 ---
-generic object: ALIncome
-code: |
-  if x.source == "other":
-    x.source_display = x.source_other
-  else:
-    x.source_display = x.display_name
----
-generic object: ALExpense
-code: |
-  if x.source == "other":
-    x.source_display = x.source_other
-  else:
-    x.source_display = x.display_name
----
 id: other income info for list
 #generic object: ALIncomeList
 question: |
   Tell us about your ${ ordinal(i) } income
 subquestion: |
   % if i > 1:
-  You have already told us about your incomes from ${ comma_and_list([income.source_display for income in other_incomes.complete_elements()]) }.
+  You have already told us about your incomes from ${ comma_and_list([income.display_name for income in other_incomes.complete_elements()]) }.
   % elif i > 0:
-  You have already told us about your income from ${ comma_and_list([income.source_display for income in other_incomes.complete_elements()]) }.
+  You have already told us about your income from ${ comma_and_list([income.display_name for income in other_incomes.complete_elements()]) }.
   % endif
 fields:
   - Source of income: other_incomes[i].source
@@ -665,7 +697,7 @@ table: jobs.table
 rows: jobs
 columns:
   - Job title: |
-      row_item.source_display
+      row_item.display_name
   - Employer: |
       row_item.employer.name if hasattr(row_item.employer.name, "first") else ""
   - Monthly Gross Income: |
@@ -927,18 +959,6 @@ fields:
 
       **"Other insurance" you might enter:** dental, vision, home, rental, life insurance and more.
 ---
-generic object: ALIncome
-code: |
-  x.check_for_other
-  x.value
-  x.source_display
-  x.complete = True
----
-code: |
-  if not hasattr(public_benefits[i],'source') and i < len(public_benefits.selected_types.true_values()):
-    public_benefits[i].source = 'other'
-  public_benefits[i].check_for_other = True
----
 code: |
   if not hasattr(other_incomes[i],'source') and i < len(other_incomes.selected_types.true_values()):
     other_incomes[i].source = 'other'
@@ -1190,26 +1210,6 @@ code: |
     other_assets[i].source = 'other'
   other_assets[i].check_for_other = True
 ---
-# workaround to get the display names to show and to be able to add a benefit in review screen
-id: public benefits display names
-code: |
-  public_benefits.display_name = public_benefits.terms_ordered.get(x.source, x.source)
----
-id: real estate display names
-#generic object: ALAsset
-code: |
-  real_estate.display_name = real_estate.terms_ordered.get(x.source, x.source)
----
-id: other asset display names
-#generic object: ALAsset
-code: |
-  other_asset.display_name = other_asset.terms_ordered.get(x.source, x.source)
----
-id: bank assets display names
-#generic object: ALAsset
-code: |
-  bank_assets.display_name = bank_assets.terms_ordered.get(x.source, x.source)
----
 ###############################OTHER ASSETS#############################
 ---
 ---
@@ -1266,6 +1266,11 @@ fields:
   - Current value: bank_assets[i].market_value
     datatype: currency
     required: False
+---
+id: bank assets display names
+#generic object: ALAsset
+code: |
+  bank_assets.display_name = bank_assets.terms_ordered.get(x.source, x.source)
 ---
 #############################OTHER REASONS#############################
 ---
@@ -1348,15 +1353,6 @@ code: |
   
 
 #####################REVIEW SCREEN#######################
----
-#This code is a workaround for an error that you get when you edit these in review table
-code: |
-  public_benefits.there_is_another = False
-  other_incomes.there_is_another = False
-  bank_assets.there_is_another = False
----
-question: Do you want to add any more public benefits?
-yesno: public_benefits.there_is_another
 ---
 question: Do you want to add any more incomes?
 yesno: other_incomes.there_is_another
@@ -1612,26 +1608,6 @@ edit:
   - daytime_phone_number
   - signature
 confirm: True
----
-continue button field: public_benefits.revisit
-question: |
-  Edit public assistance
-subquestion: |
-  ${ public_benefits.table }
-
-  ${ public_benefits.add_action() }
----
-table: public_benefits.table
-rows: public_benefits
-columns:
-  - Source: |
-      row_item.source_display if defined("row_item.source") else ""
-  - Amount: |
-      currency(row_item.value) if defined("row_item.value") else ""
-edit:
-  - source
-  - value
----
 
 ---
 continue button field: other_incomes.revisit

--- a/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
+++ b/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
@@ -8,6 +8,9 @@ include:
 objects:
   - all_courts: ALCourtLoader.using(file_name='courts_list_full.xlsx')
 ---
+modules:
+  - .al_income_move
+---
 code: |
   trial_court_index = all_courts.matching_courts_in_county(county_name=user_selected_county,search_columns=['division_abbr'],search_string=trial_court_division)[0][0]
 ---
@@ -308,15 +311,8 @@ fields:
 id: ALIncome complete
 generic object: ALIncome
 code: |
-  x.check_for_other
   x.value
   x.complete = True
----
-id: public_benefits check for other
-code: |
-  if not hasattr(public_benefits[i],'source') and i < len(public_benefits.selected_types.true_values()):
-    public_benefits[i].source = 'other'
-  public_benefits[i].check_for_other = True
 ---
 id: public benefits info for list
 #generic object: ALIncomeList
@@ -443,12 +439,6 @@ fields:
 comment: |
   will use id: ALIncome complete to set other_incomes[i].complete
 ---
-id: other_incomes check for other
-code: |
-  if not hasattr(other_incomes[i],'source') and i < len(other_incomes.selected_types.true_values()):
-    other_incomes[i].source = 'other'
-  other_incomes[i].check_for_other = True
----
 id: other income info for list
 #generic object: ALIncomeList
 reconsider: other_incomes[i].display_name
@@ -495,11 +485,6 @@ code: |
     other_incomes[i].display_name = other_incomes[i].source_other
   else:
     other_incomes[i].display_name = other_incomes_other_display
----
-code: |
-  if not hasattr(other_incomes[i],'source') and i < len(other_incomes.selected_types.true_values()):
-    other_incomes[i].source = 'other'
-  other_incomes[i].check_for_other = True
 ---
 question: Do you want to add any more incomes?
 yesno: other_incomes.there_is_another
@@ -1063,14 +1048,8 @@ fields:
 ---
 generic object: ALExpense
 code: |
-  x.check_for_other
   x.value
   x.complete = True
----
-code: |
-  if not hasattr(expenses[i],'source') and i < len(expenses.selected_types.true_values()):
-    expenses[i].source = 'other'
-  expenses[i].check_for_other = True
 ---
 generic object: ALExpenseList
 need:
@@ -1239,16 +1218,8 @@ fields:
 id: vehicles complete
 generic object: ALVehicleList
 code: |
-  x[i].check_for_other
   x[i].market_value
   x[i].complete = True
----
-id: vehicles check for other
-generic object: ALVehicle
-code: |
-  if x.source == 'vehicle' and i < len(vehicles.selected_types.true_values()):
-    x.source = 'other'
-  x.check_for_other = True
 ---
 id: info for each vehicle
 reconsider: vehicles[i].display_name
@@ -1364,15 +1335,8 @@ fields:
       real_estate_ordered
 ---
 code: |
-  real_estate[i].check_for_other
   real_estate[i].market_value
   real_estate[i].complete = True
----
-id: real_estate check for other
-code: |
-  if not hasattr(real_estate[i],'source') and i < len(real_estate.selected_types.true_values()):
-    real_estate[i].source = 'other'
-  real_estate[i].check_for_other = True
 ---
 id: info for each real estate
 reconsider: real_estate[i].display_name
@@ -1491,15 +1455,8 @@ fields:
 ---
 id: other_assets complete
 code: |
-  other_assets[i].check_for_other
   other_assets[i].market_value
   other_assets[i].complete = True
----
-id: other_assets check for other
-code: |
-  if not hasattr(other_assets[i],'source') and i < len(other_assets.selected_types.true_values()):
-    other_assets[i].source = 'other'
-  other_assets[i].check_for_other = True
 ---
 id: describe other asset
 reconsider: other_assets[i].display_name

--- a/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
+++ b/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
@@ -727,7 +727,7 @@ columns:
   - Type: |
       str(row_index).replace("_", " ").lower().capitalize()
   - Amount per hour or other time period: |
-      '$0' if hasattr(row_item, 'exists') and not row_item.exists else currency(row_item.value)
+      currency(row_item.value)
   
 edit:
   #- exists
@@ -743,7 +743,7 @@ columns:
   - Type: |
       str(row_index).replace("_", " ").lower().capitalize()
   - Amount: |
-      '$0' if hasattr(row_item, 'exists') and not row_item.exists else currency(row_item.value)
+      currency(row_item.value)
 edit:
   #- exists
   - is_part_time
@@ -830,7 +830,10 @@ columns:
   - Type: |
       str(row_index).replace("_", " ").lower().capitalize()
   - Amount: |
-      '$0' if hasattr(row_item, 'exists') and not row_item.exists else currency(row_item.value)
+      currency(row_item.value)
+  - Period: |
+      times_per_year(times_per_year_list, row_item.times_per_year)
+      
   
 edit:
   #- exists
@@ -1569,11 +1572,9 @@ table: other_assets_table
 rows: other_assets.complete_elements()
 columns:
   - Description: |
-      row_item.source if defined("row_item.source") else ""
+      row_item.display_name if defined("row_item.source") else ""
   - Market value: |
       currency(row_item.market_value) if defined("row_item.market_value") else ""
-  - Amount owed: |
-      currency(row_item.balance) if defined("row_item.balance") else ""
 edit:
   - source
   - market_value
@@ -1609,7 +1610,7 @@ fields:
     code: |
       bank_assets_ordered
 ---
-id: info for each asset
+id: info for each bank asset
 question: |
   About your cash and bank assets
 fields:
@@ -1807,7 +1808,7 @@ review:
       % endif
       
       % for item in jobs:
-      - ${ item.source } / ${ item.employer.name }
+      - ${ item.source } / ${ item.employer.name.first if not item.is_self_employed else "Self-employed"}
       % endfor     
   - Edit: users1_income_self_employment_monthly_amount
     button: |

--- a/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
+++ b/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
@@ -13,7 +13,6 @@ code: |
 ---
 objects:
   - users: ALPeopleList.using(ask_number=True,target_number=1)
-  - public_benefits: ALIncomeList.using(complete_attribute='complete')
   - jobs: ALItemizedJobList.using(complete_attribute="complete", ask_number=True)
   - other_incomes: ALIncomeList.using(complete_attribute='complete')
   - expenses: ALExpenseList.using(complete_attribute='complete')
@@ -279,6 +278,17 @@ data: !!omap
   - medicaid: "Medicaid"
   - other: "Other"
 ---
+comment: |
+  This keeps the text that may be changed near the top of the public benefits section.
+code: |
+  public_benefits_other_display = "another benefit that provides you income"
+---
+objects:
+  - public_benefits: ALIncomeList.using(complete_attribute='complete')
+---
+objects:
+  - benefits_ordered: DAOrderedDict.using(elements=public_benefits.terms_ordered, auto_gather=False, gathered=True)
+---
 generic object: ALIncomeList
 code: |
   if x.selected_types.any_true():
@@ -353,7 +363,7 @@ code: |
   elif defined('public_benefits[i].source') and public_benefits[i].source == "other" and defined('public_benefits[i].source_other'):
     public_benefits[i].display_name = public_benefits[i].source_other
   else:
-    public_benefits[i].display_name = "another benefit that provides you income"
+    public_benefits[i].display_name = public_benefits_other_display
 ---
 question: Do you want to add any more public benefits?
 subquestion: |
@@ -902,7 +912,6 @@ validation code: |
 ---
 objects:
   # workaround to get omaps lists to be ordered
-  - benefits_ordered: DAOrderedDict.using(elements=public_benefits.terms_ordered, auto_gather=False, gathered=True)
   - other_incomes_ordered: DAOrderedDict.using(elements=other_incomes.terms_ordered, auto_gather=False, gathered=True)
   - expenses_ordered: DAOrderedDict.using(elements=expenses.terms_ordered, auto_gather=False, gathered=True)
   - vehicles_ordered: DAOrderedDict.using(elements=vehicles.terms_ordered, auto_gather=False, gathered=True)

--- a/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
+++ b/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
@@ -14,12 +14,6 @@ code: |
 objects:
   - users: ALPeopleList.using(ask_number=True,target_number=1)
   - jobs: ALItemizedJobList.using(complete_attribute="complete", ask_number=True)
-  - other_incomes: ALIncomeList.using(complete_attribute='complete')
-  - expenses: ALExpenseList.using(complete_attribute='complete')
-  - bank_assets: ALAssetList.using(complete_attribute='value')
-  - vehicles: ALVehicleList.using(complete_attribute='complete')
-  - real_estate: ALAssetList.using(complete_attribute='complete')
-  - other_assets: ALAssetList.using(complete_attribute='complete')
 ---
 comment: |
   Global interview metadata
@@ -228,15 +222,6 @@ code: |
   set_progress(100)
   VT_fee_waiver_download
 ---
-
-
-#generic object: ALIncomeList
-#code: |
-#  x.move_checks_to_list(selected_terms=other_incomes_ordered)
-#  x.update_names = True
-
-
----
 #################################PUBLIC BENEFITS##############################
 comment: |
   Notes on how a list is gathered
@@ -266,6 +251,7 @@ comment: |
 
   complete sets display  
 ---
+id: public_benefits terms_ordered
 variable name: public_benefits.terms_ordered
 data: !!omap
   - reach up: "Reach Up"
@@ -278,17 +264,23 @@ data: !!omap
   - medicaid: "Medicaid"
   - other: "Other"
 ---
+id: public_benefits other display
 comment: |
   This keeps the text that may be changed near the top of the public benefits section.
+  Used in:
+  Tell us about ______.
 code: |
   public_benefits_other_display = "another benefit that provides you income"
 ---
+id: public_benefits object
 objects:
   - public_benefits: ALIncomeList.using(complete_attribute='complete')
 ---
+id: public_benefits ordered object for checkboxes
 objects:
-  - benefits_ordered: DAOrderedDict.using(elements=public_benefits.terms_ordered, auto_gather=False, gathered=True)
+  - public_benefits_ordered: DAOrderedDict.using(elements=public_benefits.terms_ordered, auto_gather=False, gathered=True)
 ---
+id: ALIncomeList there are any
 generic object: ALIncomeList
 code: |
   if x.selected_types.any_true():
@@ -311,14 +303,16 @@ fields:
   - no label: public_benefits.selected_types
     datatype: checkboxes
     code: |
-      benefits_ordered
+      public_benefits_ordered
 ---
+id: ALIncome complete
 generic object: ALIncome
 code: |
   x.check_for_other
   x.value
   x.complete = True
 ---
+id: public_benefits check for other
 code: |
   if not hasattr(public_benefits[i],'source') and i < len(public_benefits.selected_types.true_values()):
     public_benefits[i].source = 'other'
@@ -339,7 +333,7 @@ fields:
   - Source of income: public_benefits[i].source
     input type: dropdown
     code: |
-      benefits_ordered
+      public_benefits_ordered
   - What type of income?: public_benefits[i].source_other
     show if:
       variable: public_benefits[i].source
@@ -357,6 +351,7 @@ validation code: |
   else:
     public_benefits[i].display_name = public_benefits[i].source_other
 ---
+id: public_benefits set display name
 code: |
   if defined('public_benefits[i].source') and public_benefits[i].source != "other":
     public_benefits[i].display_name = public_benefits.terms_ordered.get(public_benefits[i].source, public_benefits[i].source)
@@ -365,11 +360,13 @@ code: |
   else:
     public_benefits[i].display_name = public_benefits_other_display
 ---
+id: public_benefits there is another
 question: Do you want to add any more public benefits?
 subquestion: |
   ${ public_benefits_table }
 yesno: public_benefits.there_is_another
 ---
+id: public_benefits revisit
 continue button field: public_benefits.revisit
 question: |
   Edit public assistance
@@ -378,13 +375,14 @@ subquestion: |
 
   ${ public_benefits.add_action() }
 ---
+id: public_benefits table
 table: public_benefits_table
 rows: public_benefits.complete_elements()
 columns:
   - Source: |
       row_item.display_name if defined("row_item.source") else ""
-  - Amount: |
-      currency(row_item.value) if defined("row_item.value") else ""
+  - Public benefits per month: |
+      currency(row_item.total(times_per_year=12))
 edit:
   - source
   - value
@@ -413,6 +411,19 @@ data: !!omap
   - unemployment income help: "Enter gross amount of unemployment income -- before taxes were taken out."
   - default: " "
 ---
+## This keeps the text that may be changed near the top of the public benefits section.
+code: |
+  other_incomes_other_display = "other source of income"
+---
+objects:
+  - other_incomes: ALIncomeList.using(complete_attribute='complete')
+---
+objects:
+  - other_incomes_ordered: DAOrderedDict.using(elements=other_incomes.terms_ordered, auto_gather=False, gathered=True)
+---
+comment: |
+  will use id: ALIncomeList there are any to set other_incomes.there_are_any
+---
 id: are there other incomes
 #other_incomes
 question: |
@@ -429,15 +440,25 @@ fields:
   - note: |
       **Other kinds of income could include:** disability insurance?, social security?, workers compensation, veteran's income, rental income, interest income, spousal maintenance (alimony), retirement income and annuities.
 ---
+comment: |
+  will use id: ALIncome complete to set other_incomes[i].complete
+---
+id: other_incomes check for other
+code: |
+  if not hasattr(other_incomes[i],'source') and i < len(other_incomes.selected_types.true_values()):
+    other_incomes[i].source = 'other'
+  other_incomes[i].check_for_other = True
+---
 id: other income info for list
 #generic object: ALIncomeList
+reconsider: other_incomes[i].display_name
 question: |
-  Tell us about your ${ ordinal(i) } income
+  Tell us about your ${ other_incomes[i].display_name }.
 subquestion: |
   % if i > 1:
-  You have already told us about your incomes from ${ comma_and_list([income.display_name for income in other_incomes.complete_elements()]) }.
+  You have already told us about your incomes from ${ comma_and_list(public_benefit.display_name for public_benefit in other_incomes.complete_elements()) }.
   % elif i > 0:
-  You have already told us about your income from ${ comma_and_list([income.display_name for income in other_incomes.complete_elements()]) }.
+  You have already told us about your income from ${ comma_and_list(public_benefit.display_name for public_benefit in other_incomes.complete_elements()) }.
   % endif
 fields:
   - Source of income: other_incomes[i].source
@@ -461,7 +482,49 @@ fields:
       is: unemployment income
   - note: |
       **Other kinds of income could include:** disability insurance?, social security?, workers compensation, veteran's income, rental income, interest income, spousal maintenance (alimony), retirement income and annuities.
+validation code: |
+  if other_incomes[i].source != "other":
+    other_incomes[i].display_name = other_incomes.terms_ordered.get(other_incomes[i].source, other_incomes[i].source)
+  else:
+    other_incomes[i].display_name = other_incomes[i].source_other
+---
+code: |
+  if defined('other_incomes[i].source') and other_incomes[i].source != "other":
+    other_incomes[i].display_name = other_incomes.terms_ordered.get(other_incomes[i].source, other_incomes[i].source)
+  elif defined('other_incomes[i].source') and other_incomes[i].source == "other" and defined('other_incomes[i].source_other'):
+    other_incomes[i].display_name = other_incomes[i].source_other
+  else:
+    other_incomes[i].display_name = other_incomes_other_display
+---
+code: |
+  if not hasattr(other_incomes[i],'source') and i < len(other_incomes.selected_types.true_values()):
+    other_incomes[i].source = 'other'
+  other_incomes[i].check_for_other = True
+---
+question: Do you want to add any more incomes?
+yesno: other_incomes.there_is_another
+subquestion: |
+  ${ other_incomes_table }
+---
+continue button field: other_incomes.revisit
+question: |
+  Edit other incomes
+subquestion: |
+  ${ other_incomes_table }
 
+  ${ other_incomes.add_action() }
+---
+table: other_incomes_table
+rows: other_incomes.complete_elements()
+columns:
+  - Source: |
+      row_item.display_name if defined("row_item.source") else ""
+  - Income per month: |
+      currency(row_item.total(times_per_year=12))
+edit:
+  - source
+  - value
+---
 #################################JOBS##############################
 ---
 id: work
@@ -907,17 +970,38 @@ validation code: |
       (not showifdef('users[0].email')) and \
       (not showifdef('users[0].other_contact_method'))):
     validation_error(word("You need to provide at least one contact method."), field="users[0].other_contact_method")
-
-###############################WORKAROUNDS###############################
 ---
-objects:
-  # workaround to get omaps lists to be ordered
-  - other_incomes_ordered: DAOrderedDict.using(elements=other_incomes.terms_ordered, auto_gather=False, gathered=True)
-  - expenses_ordered: DAOrderedDict.using(elements=expenses.terms_ordered, auto_gather=False, gathered=True)
-  - vehicles_ordered: DAOrderedDict.using(elements=vehicles.terms_ordered, auto_gather=False, gathered=True)
-  - real_estate_ordered: DAOrderedDict.using(elements=real_estate.terms_ordered, auto_gather=False, gathered=True)
-  - bank_assets_ordered: DAOrderedDict.using(elements=bank_assets.terms_ordered, auto_gather=False, gathered=True)
-  - other_assets_ordered: DAOrderedDict.using(elements=other_assets.terms_ordered, auto_gather=False, gathered=True)
+continue button field: users.revisit
+question: |
+  Edit info about you
+subquestion: |
+  ${ users.table }
+
+  ${ users.add_action() }
+---
+table: users.table
+rows: users
+columns:
+  - Name: |
+      row_item.name.full() if defined("row_item.name.first") else ""
+  - Address: |
+      row_item.address.block() if defined("row_item.address.address") else ""
+  - Mailing address: |
+      row_item.mailing_address.block() if defined("row_item.mailing_address.address") else ""
+  - Email: |
+      row_item.email if defined("row_item.email") else ""
+  - Phone number: |
+      row_item.daytime_phone_number if defined("row_item.daytime_phone_number") else ""
+  - Signature: |
+      row_item.signature if defined("row_item.signature") else ""
+edit:
+  - name.first
+  - address.address
+  - mailing_address.address
+  - email
+  - daytime_phone_number
+  - signature
+confirm: True
 ---
 ###############################EXPENSES#############################
 ---
@@ -951,6 +1035,15 @@ data: !!omap
   - child support: "Child support payment"
   - other: "Other expenses"
 ---
+code: |
+  expenses_other_display = "another expense"
+---
+objects:
+  - expenses: ALExpenseList.using(complete_attribute='complete')
+---
+objects:
+  - expenses_ordered: DAOrderedDict.using(elements=expenses.terms_ordered, auto_gather=False, gathered=True)
+---
 generic object: ALExpenseList
 #expenses
 id: expenses types
@@ -968,19 +1061,12 @@ fields:
 
       **"Other insurance" you might enter:** dental, vision, home, rental, life insurance and more.
 ---
-code: |
-  if not hasattr(other_incomes[i],'source') and i < len(other_incomes.selected_types.true_values()):
-    other_incomes[i].source = 'other'
-  other_incomes[i].check_for_other = True
----
 generic object: ALExpense
 code: |
   x.check_for_other
   x.value
-  x.source_display
   x.complete = True
 ---
-generic object: ALExpense
 code: |
   if not hasattr(expenses[i],'source') and i < len(expenses.selected_types.true_values()):
     expenses[i].source = 'other'
@@ -1013,8 +1099,9 @@ fields:
 ---
 generic object: ALExpenseList
 id: expense information
+reconsider: expenses[i].display_name
 question: |
-  How much do you spend on your ${ ordinal(i) } household expense?
+  Tell us about your ${ expenses[i].display_name }.
 subquestion: |
   **Tip**: You can look back 12 months for this expense. That will give an accurate picture of how much the expense really is.
 fields: 
@@ -1036,8 +1123,60 @@ fields:
       **"Other expenses" you might enter:** child care, kids activities, family activities, school lunches, supplies and tuition, sports equipment, school lunches, meals eaten out, vacations, haircuts, toiletries, diapers, laundry, internet, cable, reading materials, gifts, donations, union dues, tobacco, alcohol, furniture, home repairs, mowing, trash, plowing, property taxes, water/sewer bills, car maintenance and repairs, gasoline, pet expenses, and more.
 
       **"Other insurance" you might enter:** dental, vision, home, rental, life insurance and more.
+
 validation code: |
-  x[i].display_name = expenses.terms_ordered.get(x[i].source, x[i].source)
+  if expenses[i].source != "other":
+    expenses[i].display_name = expenses.terms_ordered.get(expenses[i].source, expenses[i].source)
+  else:
+    expenses[i].display_name = expenses[i].source_other
+---
+code: |
+  if defined('expenses[i].source') and expenses[i].source != "other":
+    expenses[i].display_name = expenses.terms_ordered.get(expenses[i].source, expenses[i].source)
+  elif defined('expenses[i].source') and expenses[i].source == "other" and defined('expenses[i].source_other'):
+    expenses[i].display_name = expenses[i].source_other
+  else:
+    expenses[i].display_name = expenses_other_display
+---
+question: Do you want to add any more expenses?
+yesno: expenses.there_is_another
+subquestion: |
+  ${ expenses_table }
+---
+continue button field: expenses.revisit
+question: |
+  Edit expenses
+subquestion: |
+  ${ expenses_table }
+
+  ${ expenses.add_action() }
+---
+comment: |
+  I don't think this is used and it can be deleted
+generic object: ALExpenseList
+table: x.table
+rows: x
+columns:
+  - Type: |
+      row_item.display_name
+  - Amount per month: |
+      currency(row_item.total(times_per_year=12))
+edit:
+  - source
+  - value
+  - display_name
+
+---
+table: expenses_table
+rows: expenses.complete_elements()
+columns:
+  - Type: |
+      row_item.display_name.lower()
+  - Amount per month: |
+      currency(row_item.total(times_per_year=12))
+edit:
+  - source
+  - value
 ---
 id: assets intro
 mandatory: True
@@ -1046,11 +1185,9 @@ question: |
   Assets
 subquestion: |
   Now we will review the things that you own — your "assets" or property.
-  
+
   Tap the Next button.
----    
-
-
+---
 ################ VEHICLES CARS TRUCKS ################
 ---
 variable name: vehicles.terms_ordered
@@ -1066,6 +1203,27 @@ data: !!omap
   - plane: "Plane"
   - other: "Other"
 ---
+comment: |
+  used in this display line
+  About your ___
+code: |
+  vehicles_other_display = "other vehicle"
+---
+objects:
+  - vehicles: ALVehicleList.using(complete_attribute='complete')
+---
+objects:
+  - vehicles_ordered: DAOrderedDict.using(elements=vehicles.terms_ordered, auto_gather=False, gathered=True)
+---
+id: vehicles there are any
+generic object: ALVehicleList
+code: |
+  if x.selected_types.any_true():
+    x.move_checks_to_list(selected_terms=x.terms_ordered)
+    x.there_are_any = True
+  else:
+    x.there_are_any = False
+---
 id: are there vehicles
 #vehicles
 question: |
@@ -1078,13 +1236,14 @@ fields:
     code: |
       vehicles_ordered
 ---
+id: vehicles complete
 generic object: ALVehicleList
 code: |
   x[i].check_for_other
   x[i].market_value
-  x[i].source_display
   x[i].complete = True
 ---
+id: vehicles check for other
 generic object: ALVehicle
 code: |
   if x.source == 'vehicle' and i < len(vehicles.selected_types.true_values()):
@@ -1092,13 +1251,9 @@ code: |
   x.check_for_other = True
 ---
 id: info for each vehicle
+reconsider: vehicles[i].display_name
 question: |
-  About your 
-  % if hasattr(vehicles[i],'source'):
-  ${ vehicles[i].source }
-  % else:
-  vehicle
-  % endif
+  About your ${ vehicles[i].display_name }
 subquestion: |
   Make your best guess when answering these questions.
 fields:
@@ -1117,9 +1272,52 @@ fields:
     datatype: currency
   - If you have a loan or owe money on the ${ vehicles[i].source }, how much do you owe? Enter 0 if you own it outright.: vehicles[i].balance
     datatype: currency
+validation code: |
+  if vehicles[i].source != "other":
+    vehicles[i].display_name = vehicles.terms_ordered.get(vehicles[i].source, vehicles[i].source)
+  else:
+    vehicles[i].display_name = vehicles[i].source_other
+---
+code: |
+  if defined('vehicles[i].source') and vehicles[i].source != "other":
+    vehicles[i].display_name = vehicles.terms_ordered.get(vehicles[i].source, vehicles[i].source)
+  elif defined('vehicles[i].source') and vehicles[i].source == "other" and defined('vehicles[i].source_other'):
+    vehicles[i].display_name = vehicles[i].source_other
+  else:
+    vehicles[i].display_name = vehicles_other_display
+---
+question: Do you want to add any more vehicles?
+yesno: vehicles.there_is_another
+subquestion: |
+  ${ vehicles_table }
+---
+continue button field: vehicles.revisit
+question: |
+  Edit vehicles
+subquestion: |
+  ${ vehicles_table }
 
+  ${ vehicles.add_action() }
+---
+table: vehicles_table
+rows: vehicles.complete_elements()
+columns:
+  - Description: |
+      row_item.year_make_model() if defined("row_item.year_make_model()") else ""
+  - Market value: |
+      currency(row_item.market_value) if defined("row_item.market_value") else ""
+  - Amount owed: |
+      currency(row_item.balance) if defined("row_item.balance") else ""
+edit:
+  - make
+  - model
+  - year
+  - market_value
+  - balance
+---
 ################ REAL ESTATE ################
 ---
+id: real_estate terms_ordered
 variable name: real_estate.terms_ordered
 data: !!omap
   - primary residence: "Primary residence (where you live)"
@@ -1131,6 +1329,25 @@ data: !!omap
   - rental: "Residential rental property you own"
   - commercial: "Commercial real estate"
   - other: "Other real estate"
+---
+id: real_estate other display
+comment: |
+  This keeps the text that may be changed near the top of the public benefits section.
+  Used in:
+  Tell us about your ______.
+code: |
+  real_estate_other_display = "other real estate"
+---
+id: real_estate object
+objects:
+  - real_estate: ALAssetList.using(complete_attribute='complete')
+---
+id: real_estate ordered object for checkboxes
+objects:
+  - real_estate_ordered: DAOrderedDict.using(elements=real_estate.terms_ordered, auto_gather=False, gathered=True)
+---
+comment: |
+  This uses id: ALIncomeList there are any because  An ALAssetList is an ALIncomeList, but there may be a generic ALAssetList for there_are_any that would take precedence
 ---
 id: is there real estate
 #real_estate
@@ -1149,25 +1366,26 @@ fields:
 code: |
   real_estate[i].check_for_other
   real_estate[i].market_value
-  real_estate[i].source_display
   real_estate[i].complete = True
 ---
+id: real_estate check for other
 code: |
   if not hasattr(real_estate[i],'source') and i < len(real_estate.selected_types.true_values()):
     real_estate[i].source = 'other'
   real_estate[i].check_for_other = True
 ---
 id: info for each real estate
+reconsider: real_estate[i].display_name
 question: |
-  % if hasattr(real_estate[i],'source') and real_estate[i].source == "other":
-  About your other real estate
-  % elif hasattr(real_estate[i],'source'):
-  About your ${ real_estate[i].source }
-  % else:
-  About your real estate
-  % endif
+  Tell us about your ${ real_estate[i].display_name }.
 subquestion: |
   Make your best guess for the market value.
+
+  % if i > 1:
+  You have already told us about your ${ comma_and_list(public_benefit.display_name for public_benefit in real_estate.complete_elements()) }.
+  % elif i > 0:
+  You have already told us about your ${ comma_and_list(public_benefit.display_name for public_benefit in real_estate.complete_elements()) }.
+  % endif
 fields:
   - Type of real estate: real_estate[i].source
     code: |
@@ -1182,10 +1400,54 @@ fields:
     datatype: currency
   #- Town/city where the real estate is located. Example -- Rutland: real_estate[i].description
     #maxlength: 76
+validation code: |
+  if real_estate[i].source != "other":
+    real_estate[i].display_name = real_estate.terms_ordered.get(real_estate[i].source, real_estate[i].source)
+  else:
+    real_estate[i].display_name = real_estate[i].source_other
+---
+id: real_estate set display name
+code: |
+  if defined('real_estate[i].source') and real_estate[i].source != "other":
+    real_estate[i].display_name = real_estate.terms_ordered.get(real_estate[i].source, real_estate[i].source)
+  elif defined('real_estate[i].source') and real_estate[i].source == "other" and defined('real_estate[i].source_other'):
+    real_estate[i].display_name = real_estate[i].source_other
+  else:
+    real_estate[i].display_name = real_estate_other_display
+---
+id: real_estate there is another
+question: Do you want to add any more real estate?
+yesno: real_estate.there_is_another
+subquestion: |
+  ${ real_estate_table }
+---
+id: real_estate revisit
+continue button field: real_estate.revisit
+question: |
+  Edit real estate
+subquestion: |
+  ${ real_estate_table }
 
-
+  ${ real_estate.add_action() }
+---
+id: real_estate table
+table: real_estate_table
+rows: real_estate.complete_elements()
+columns:
+  - Description: |
+      row_item.display_name if defined("row_item.source") else ""
+  - Market value: |
+      currency(row_item.market_value) if defined("row_item.market_value") else ""
+  - Amount owed: |
+      currency(row_item.balance) if defined("row_item.balance") else ""
+edit:
+  - source
+  - market_value
+  - balance
+---
 ################ OTHER ASSETS ################
 ---
+id: other_assets terms_ordered
 # "!!omap" makes these terms ordered
 # their order here will be their same order when shown to users.
 variable name: other_assets.terms_ordered
@@ -1196,6 +1458,25 @@ data: !!omap
   - stocks: "Stocks"
   - bonds: "Bonds"
   - other: "Other"
+---
+id: other_assets other display
+comment: |
+  This keeps the text that may be changed near the top of the public benefits section.
+  Used in:
+  Tell us about your ______.
+code: |
+  other_assets_other_display = "other asset"
+---
+id: other_assets object
+objects:
+  - other_assets: ALAssetList.using(complete_attribute='complete')
+---
+id: other_assets ordered object for checkboxes
+objects:
+  - other_assets_ordered: DAOrderedDict.using(elements=other_assets.terms_ordered, auto_gather=False, gathered=True)
+---
+comment: |
+  will use id: ALIncomeList there are any
 ---
 id: other assets
 question: |
@@ -1208,26 +1489,31 @@ fields:
     code: |
       other_assets_ordered
 ---
+id: other_assets complete
 code: |
   other_assets[i].check_for_other
   other_assets[i].market_value
-  other_assets[i].source_display
   other_assets[i].complete = True
 ---
+id: other_assets check for other
 code: |
   if not hasattr(other_assets[i],'source') and i < len(other_assets.selected_types.true_values()):
     other_assets[i].source = 'other'
   other_assets[i].check_for_other = True
 ---
-###############################OTHER ASSETS#############################
----
----
 id: describe other asset
+reconsider: other_assets[i].display_name
 question: |
-  Describe the ${ ordinal(i) } other asset
+  Tell us about your ${ other_assets[i].display_name }.
 subquestion: |
 
   Make your best guess for the market value.
+  
+  % if i > 1:
+  You have already told us about your ${ comma_and_list(other_asset.display_name for other_asset in other_assets.complete_elements()) }.
+  % elif i > 0:
+  You have already told us about your ${ comma_and_list(other_asset.display_name for other_asset in other_assets.complete_elements()) }.
+  % endif
 fields:
   - Type of asset: other_assets[i].source
     code: |
@@ -1241,16 +1527,65 @@ fields:
     datatype: currency
   - note: |
       Other assets may be things like tools, equipment, electronics, computers, stocks, bonds, etc.
+validation code: |
+  if other_assets[i].source != "other":
+    other_assets[i].display_name = other_assets.terms_ordered.get(other_assets[i].source, other_assets[i].source)
+  else:
+    other_assets[i].display_name = other_assets[i].source_other
 ---
+id: other_assets set display name
+code: |
+  if defined('other_assets[i].source') and other_assets[i].source != "other":
+    other_assets[i].display_name = other_assets.terms_ordered.get(other_assets[i].source, other_assets[i].source)
+  elif defined('other_assets[i].source') and other_assets[i].source == "other" and defined('other_assets[i].source_other'):
+    other_assets[i].display_name = other_assets[i].source_other
+  else:
+    other_assets[i].display_name = other_assets_other_display
+---
+question: Do you want to add any more other assets?
+yesno: other_assets.there_is_another
+subquestion: |
+  ${ other_assets_table }
+---
+continue button field: other_assets.revisit
+question: |
+  Edit other assets
+subquestion: |
+  ${ other_assets_table }
 
+  ${ other_assets.add_action() }
+---
+table: other_assets_table
+rows: other_assets.complete_elements()
+columns:
+  - Description: |
+      row_item.source if defined("row_item.source") else ""
+  - Market value: |
+      currency(row_item.market_value) if defined("row_item.market_value") else ""
+  - Amount owed: |
+      currency(row_item.balance) if defined("row_item.balance") else ""
+edit:
+  - source
+  - market_value
+  - balance
 
+---
 ###############BANK ASSETS####################
 ---
+id: bank_assets terms_ordered
 variable name: bank_assets.terms_ordered
 data: !!omap
   - checking account: "Checking accounts"
   - savings account: "Savings accounts"
   - cash on hand: "Cash on hand"
+---
+id: bank_assets object
+objects:
+  - bank_assets: ALAssetList.using(complete_attribute='market_value')
+---
+id: bank_assets ordered object for checkboxes
+objects:
+  - bank_assets_ordered: DAOrderedDict.using(elements=bank_assets.terms_ordered, auto_gather=False, gathered=True)
 ---
 id: are there bank assets
 #bank_assets
@@ -1277,9 +1612,35 @@ fields:
     required: False
 ---
 id: bank assets display names
-#generic object: ALAsset
 code: |
-  bank_assets.display_name = bank_assets.terms_ordered.get(x.source, x.source)
+  bank_assets[i].display_name = bank_assets.terms_ordered.get(bank_assets[i].source, bank_assets[i].source)
+---
+id: bank_assets there is another
+question: Do you want to add any more bank assets?
+yesno: bank_assets.there_is_another
+subquestion: |
+  ${ bank_assets_table }
+---
+id: bank_assets revisit
+continue button field: bank_assets.revisit
+question: |
+  Edit bank accounts and cash
+subquestion: |
+  ${ bank_assets_table }
+
+  ${ bank_assets.add_action() }
+---
+id: bank_assets table
+table: bank_assets_table
+rows: bank_assets.complete_elements()
+columns:
+  - Source: |
+      row_item.display_name if defined("row_item.source") else ""
+  - Value: |
+      currency(row_item.market_value) if defined("row_item.market_value") else ""
+edit:
+  - source
+  - market_value
 ---
 #############################OTHER REASONS#############################
 ---
@@ -1362,24 +1723,6 @@ code: |
   
 
 #####################REVIEW SCREEN#######################
----
-question: Do you want to add any more incomes?
-yesno: other_incomes.there_is_another
----
-question: Do you want to add any more bank assets?
-yesno: bank_assets.there_is_another
----
-question: Do you want to add any more expenses?
-yesno: expenses.there_is_another
----
-question: Do you want to add any more vehicles?
-yesno: vehicles.there_is_another
----
-question: Do you want to add any more real estate?
-yesno: real_estate.there_is_another
----
-question: Do you want to add any more other assets?
-yesno: other_assets.there_is_another
 ---
 id: VT fee waiver review screen
 event: review_VT_fee_waiver
@@ -1494,11 +1837,8 @@ review:
       % endif
       
       % for item in expenses:
-      % if item.display_name == "Other expenses":
-      - ${ item.source_display.lower() }
-      % else:
       - ${ item.display_name.lower() }
-      % endif
+      
       % endfor
 
  
@@ -1523,7 +1863,7 @@ review:
       **Real estate**
 
       % for item in real_estate.complete_elements():
-      * ${ item.source_display }       
+      * ${ item.display_name }       
       % endfor
       % if not real_estate.there_are_any:
       - None
@@ -1549,7 +1889,7 @@ review:
       **Other assets**
 
       % for item in other_assets.complete_elements():
-        - ${ item.source_display }
+        - ${ item.display_name }
       % endfor
 
       % if not other_assets.there_are_any:
@@ -1570,184 +1910,6 @@ review:
     button: |
       **Date of signature for these forms**:
       ${ signature_date }
-
----
-generic object: ALExpenseList
-table: x.table
-rows: x
-columns:
-  - Type: |
-      row_item.display_name
-  - Amount per month: |
-      currency(row_item.total(times_per_year=12))
-edit:
-  - source
-  - value
-  - display_name
-
----
-continue button field: users.revisit
-question: |
-  Edit info about you
-subquestion: |
-  ${ users.table }
-
-  ${ users.add_action() }
----
-table: users.table
-rows: users
-columns:
-  - Name: |
-      row_item.name.full() if defined("row_item.name.first") else ""
-  - Address: |
-      row_item.address.block() if defined("row_item.address.address") else ""
-  - Mailing address: |
-      row_item.mailing_address.block() if defined("row_item.mailing_address.address") else ""
-  - Email: |
-      row_item.email if defined("row_item.email") else ""
-  - Phone number: |
-      row_item.daytime_phone_number if defined("row_item.daytime_phone_number") else ""
-  - Signature: |
-      row_item.signature if defined("row_item.signature") else ""
-edit:
-  - name.first
-  - address.address
-  - mailing_address.address
-  - email
-  - daytime_phone_number
-  - signature
-confirm: True
-
----
-continue button field: other_incomes.revisit
-question: |
-  Edit other incomes
-subquestion: |
-  ${ other_incomes.table }
-
-  ${ other_incomes.add_action() }
----
-table: other_incomes.table
-rows: other_incomes
-columns:
-  - Source: |
-      row_item.source_display if defined("row_item.source") else ""
-  - Value: |
-      currency(row_item.value) if defined("row_item.value") else ""
-edit:
-  - source
-  - value
-
----
-continue button field: expenses.revisit
-question: |
-  Edit expenses
-subquestion: |
-  ${ expenses.table }
-
-  ${ expenses.add_action() }
----
-table: expenses.table
-rows: expenses
-columns:
-  - Type: |
-      row_item.source_display.lower()
-  - Amount per month: |
-      currency(row_item.total(times_per_year=12))
-edit:
-  - source
-  - value
-  - display_name
----
-continue button field: bank_assets.revisit
-question: |
-  Edit bank accounts and cash
-subquestion: |
-  ${ bank_assets.table }
-
-  ${ bank_assets.add_action() }
----
-table: bank_assets.table
-rows: bank_assets
-columns:
-  - Source: |
-      row_item.source_display if defined("row_item.source") else ""
-  - Value: |
-      currency(row_item.market_value) if defined("row_item.market_value") else ""
-edit:
-  - source
-  - market_value
----
----
-continue button field: vehicles.revisit
-question: |
-  Edit vehicles
-subquestion: |
-  ${ vehicles.table }
-
-  ${ vehicles.add_action() }
----
-table: vehicles.table
-rows: vehicles
-columns:
-  - Description: |
-      row_item.year_make_model() if defined("row_item.year_make_model()") else ""
-  - Market value: |
-      currency(row_item.market_value) if defined("row_item.market_value") else ""
-  - Amount owed: |
-      currency(row_item.balance) if defined("row_item.balance") else ""
-edit:
-  - make
-  - model
-  - year
-  - market_value
-  - balance
----
-continue button field: real_estate.revisit
-question: |
-  Edit real estate
-subquestion: |
-  ${ real_estate.table }
-
-  ${ real_estate.add_action() }
----
-table: real_estate.table
-rows: real_estate
-columns:
-  - Description: |
-      row_item.source_display if defined("row_item.source") else ""
-  - Market value: |
-      currency(row_item.market_value) if defined("row_item.market_value") else ""
-  - Amount owed: |
-      currency(row_item.balance) if defined("row_item.balance") else ""
-edit:
-  - source
-  - market_value
-  - balance
-  
----
----
-continue button field: other_assets.revisit
-question: |
-  Edit other assets
-subquestion: |
-  ${ other_assets.table }
-
-  ${ other_assets.add_action() }
----
-table: other_assets.table
-rows: other_assets
-columns:
-  - Description: |
-      row_item.source if defined("row_item.source") else ""
-  - Market value: |
-      currency(row_item.market_value) if defined("row_item.market_value") else ""
-  - Amount owed: |
-      currency(row_item.balance) if defined("row_item.balance") else ""
-edit:
-  - source
-  - market_value
-  - balance
 
 ---
 #####################DOWNLOAD SCREEN#####################

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='docassemble.VTFeeWaiver',
       url='https://VTLawHelp.org/VTCourtForms',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.11.0', 'docassemble.AssemblyLine>=3.0.1', 'docassemble.GithubFeedbackForm>=0.4.0', 'docassemble.VTFeedback', 'docassemble.VTSharedYMLFile'],
+      install_requires=['docassemble.ALToolbox>=0.11.0', 'docassemble.AssemblyLine>=3.1.0', 'docassemble.GithubFeedbackForm>=0.4.0', 'docassemble.VTFeedback', 'docassemble.VTSharedYMLFile'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/VTFeeWaiver/', package='docassemble.VTFeeWaiver'),
      )


### PR DESCRIPTION
This pull request reorganizes all the lists that now
- allow somebody to select "other" as an option for source, and the default will work correctly on the follow up screen
- display_name will now gather the source or what is entered in other (and also can be used before the source is set)
- allow somebody to add wage and non-wage income for jobs


I also added a module, which is the same as al_income.py except for two differences -

In the _item_value_per_times_per_year method, the following line was changed to only require is_hourly to be set for to_add item
`         is_hourly = hasattr(item, "is_hourly") and item.is_hourly`

In the method move_checks_to_list, the method now returns "other" as source if other is selected.

fix #62 
fix #60 
fix #59 
fix #51
fix #50
fix #49
fix #48
fix #46 
fix #44 
fix #42 
fix #41

