### PR TITLE
Add add another

### DIFF
--- a/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
+++ b/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
@@ -123,7 +123,7 @@ code: |
   trial_court.address.county
   
   nav.set_section('your_income')
-  if len(public_benefits) > 0:
+  if public_benefits.there_are_any:
     public_benefits.review_items
     user_qualifies_interstitial   
     if employed:
@@ -135,25 +135,31 @@ code: |
       review_jobs
     set_progress(40)
     
-    other_incomes.gather()
+    if other_incomes.there_are_any:
+      other_incomes.review_items
 
     set_progress(50)
     nav.set_section('your_expenses')
     expenses_intro
-    expenses.gather()
+    if expenses.there_are_any:
+      expenses.review_items
 
     set_progress(60)
     nav.set_section('your_assets')
     assets_intro
   
-    vehicles.gather()
+    if vehicles.there_are_any:
+      vehicles.review_items
   
-    real_estate.gather()
+    if real_estate.there_are_any:
+      real_estate.review_items
         
     set_progress(70)
-    bank_assets.gather()
-        
-    other_assets.gather()
+    if bank_assets.there_are_any:
+      bank_assets.review_items    
+    
+    if other_assets.there_are_any:
+      other_assets.review_items        
       
     nav.set_section('reasons')
     other_reasons_why_cannot_afford
@@ -389,7 +395,7 @@ code: |
   other_incomes_other_display = "other source of income"
 ---
 objects:
-  - other_incomes: ALIncomeList.using(complete_attribute='complete')
+  - other_incomes: ALIncomeList.using(complete_attribute='complete',there_is_another=False)
 ---
 objects:
   - other_incomes_ordered: DAOrderedDict.using(elements=other_incomes.terms_ordered, auto_gather=False, gathered=True)
@@ -464,9 +470,11 @@ code: |
     other_incomes[i].display_name = other_incomes_other_display
 ---
 question: Do you want to add any more incomes?
-yesno: other_incomes.there_is_another
 subquestion: |
   ${ other_incomes_table }
+  
+  ${ other_incomes.add_action() }
+continue button field: other_incomes.review_items
 ---
 continue button field: other_incomes.revisit
 question: |
@@ -477,7 +485,7 @@ subquestion: |
   ${ other_incomes.add_action() }
 ---
 table: other_incomes_table
-rows: other_incomes.complete_elements()
+rows: other_incomes
 columns:
   - Source: |
       row_item.display_name if defined("row_item.source") else ""
@@ -1082,7 +1090,7 @@ code: |
   expenses_other_display = "another expense"
 ---
 objects:
-  - expenses: ALExpenseList.using(complete_attribute='complete')
+  - expenses: ALExpenseList.using(complete_attribute='complete',there_is_another=False)
 ---
 objects:
   - expenses_ordered: DAOrderedDict.using(elements=expenses.terms_ordered, auto_gather=False, gathered=True)
@@ -1176,9 +1184,11 @@ code: |
     expenses[i].display_name = expenses_other_display
 ---
 question: Do you want to add any more expenses?
-yesno: expenses.there_is_another
 subquestion: |
   ${ expenses_table }
+  
+  ${ expenses.add_action() }
+continue button field: expenses.review_items
 ---
 continue button field: expenses.revisit
 question: |
@@ -1205,7 +1215,7 @@ edit:
 
 ---
 table: expenses_table
-rows: expenses.complete_elements()
+rows: expenses
 columns:
   - Type: |
       row_item.display_name.lower()
@@ -1247,7 +1257,7 @@ code: |
   vehicles_other_display = "other vehicle"
 ---
 objects:
-  - vehicles: ALVehicleList.using(complete_attribute='complete')
+  - vehicles: ALVehicleList.using(complete_attribute='complete',there_is_another=False)
 ---
 objects:
   - vehicles_ordered: DAOrderedDict.using(elements=vehicles.terms_ordered, auto_gather=False, gathered=True)
@@ -1316,9 +1326,11 @@ code: |
     vehicles[i].display_name = vehicles_other_display
 ---
 question: Do you want to add any more vehicles?
-yesno: vehicles.there_is_another
 subquestion: |
   ${ vehicles_table }
+  
+  ${ vehicles.add_action() }
+continue button field: vehicles.review_items
 ---
 continue button field: vehicles.revisit
 question: |
@@ -1329,7 +1341,7 @@ subquestion: |
   ${ vehicles.add_action() }
 ---
 table: vehicles_table
-rows: vehicles.complete_elements()
+rows: vehicles
 columns:
   - Description: |
       row_item.year_make_model() if defined("row_item.year_make_model()") else ""
@@ -1369,7 +1381,7 @@ code: |
 ---
 id: real_estate object
 objects:
-  - real_estate: ALAssetList.using(complete_attribute='complete')
+  - real_estate: ALAssetList.using(complete_attribute='complete',there_is_another=False)
 ---
 id: real_estate ordered object for checkboxes
 objects:
@@ -1439,9 +1451,11 @@ code: |
 ---
 id: real_estate there is another
 question: Do you want to add any more real estate?
-yesno: real_estate.there_is_another
 subquestion: |
   ${ real_estate_table }
+  
+  ${ real_estate.add_action() }
+continue button field: real_estate.review_items
 ---
 id: real_estate revisit
 continue button field: real_estate.revisit
@@ -1454,7 +1468,7 @@ subquestion: |
 ---
 id: real_estate table
 table: real_estate_table
-rows: real_estate.complete_elements()
+rows: real_estate
 columns:
   - Description: |
       row_item.display_name if defined("row_item.source") else ""
@@ -1491,7 +1505,7 @@ code: |
 ---
 id: other_assets object
 objects:
-  - other_assets: ALAssetList.using(complete_attribute='complete')
+  - other_assets: ALAssetList.using(complete_attribute='complete',there_is_another=False)
 ---
 id: other_assets ordered object for checkboxes
 objects:
@@ -1558,9 +1572,11 @@ code: |
     other_assets[i].display_name = other_assets_other_display
 ---
 question: Do you want to add any more other assets?
-yesno: other_assets.there_is_another
 subquestion: |
   ${ other_assets_table }
+  
+  ${ other_assets.add_action() }
+continue button field: other_assets.review_items
 ---
 continue button field: other_assets.revisit
 question: |
@@ -1571,7 +1587,7 @@ subquestion: |
   ${ other_assets.add_action() }
 ---
 table: other_assets_table
-rows: other_assets.complete_elements()
+rows: other_assets
 columns:
   - Description: |
       row_item.display_name if defined("row_item.source") else ""
@@ -1594,7 +1610,7 @@ data: !!omap
 ---
 id: bank_assets object
 objects:
-  - bank_assets: ALAssetList.using(complete_attribute='market_value')
+  - bank_assets: ALAssetList.using(complete_attribute='market_value',there_is_another=False)
 ---
 id: bank_assets ordered object for checkboxes
 objects:
@@ -1630,9 +1646,11 @@ code: |
 ---
 id: bank_assets there is another
 question: Do you want to add any more bank assets?
-yesno: bank_assets.there_is_another
 subquestion: |
   ${ bank_assets_table }
+  
+  ${ bank_assets.add_action() }
+continue button field: bank_assets.review_items
 ---
 id: bank_assets revisit
 continue button field: bank_assets.revisit
@@ -1645,7 +1663,7 @@ subquestion: |
 ---
 id: bank_assets table
 table: bank_assets_table
-rows: bank_assets.complete_elements()
+rows: bank_assets
 columns:
   - Source: |
       row_item.display_name if defined("row_item.source") else ""

--- a/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
+++ b/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
@@ -123,8 +123,8 @@ code: |
   trial_court.address.county
   
   nav.set_section('your_income')
-  public_benefits.gather()
-  if public_benefits.there_are_any:
+  if len(public_benefits) > 0:
+    public_benefits.review_items
     user_qualifies_interstitial   
     if employed:
       jobs.gather()
@@ -252,7 +252,7 @@ code: |
 ---
 id: public_benefits object
 objects:
-  - public_benefits: ALIncomeList.using(complete_attribute='complete')
+  - public_benefits: ALIncomeList.using(complete_attribute='complete',there_is_another=False)
 ---
 id: public_benefits ordered object for checkboxes
 objects:
@@ -335,7 +335,9 @@ id: public_benefits there is another
 question: Do you want to add any more public benefits?
 subquestion: |
   ${ public_benefits_table }
-yesno: public_benefits.there_is_another
+  
+  ${ public_benefits.add_action() }
+continue button field: public_benefits.review_items
 ---
 id: public_benefits revisit
 continue button field: public_benefits.revisit
@@ -348,7 +350,7 @@ subquestion: |
 ---
 id: public_benefits table
 table: public_benefits_table
-rows: public_benefits.complete_elements()
+rows: public_benefits
 columns:
   - Source: |
       row_item.display_name if defined("row_item.source") else ""


### PR DESCRIPTION
fix #68 to add "Add another" to every review screen

For every list
- i changed interview order to remove gather and add reference to review screen (.review_items)
- add there_is_another=False to the object definitions
- changed the there_is_another to .review_items and added add_action()
- changed table from complete_elements