### PR TITLE
added exclude_source to function

### DIFF
--- a/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
+++ b/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
@@ -2248,10 +2248,10 @@ attachments:
           % endif
       
       - "users1_income_employment_monthly_amount": |
-          % if jobs.total(source=["full time","part time"],times_per_year=12) == 0:
+          % if jobs.total(times_per_year=12,exclude_source=["self employed"]) == 0:
           
           % else:
-          ${ currency(jobs.gross_total(source=["full time","part time"],times_per_year=12),symbol="") }
+          ${ currency(jobs.gross_total(exclude_source=["self employed"], times_per_year=12),symbol="") }
           % endif
       
       - "users1_income_unemployment_monthly_amount": |
@@ -2276,19 +2276,15 @@ attachments:
           % endif   
       
       - "users1_income_self_employment_monthly_amount": |
-
-          % if defined("jobs"):
+          % if jobs.total(source=["self employed"],times_per_year=12) != 0:
           ${ currency(jobs.total(source=["self employed"],times_per_year=12),symbol="") }
-
           % else:
-          
+          test
           % endif
-
       - "users1_income_monthly_total": |
           % if defined("jobs"):
-          ${ currency(float(jobs.gross_total(source=["full time","part time","self employed"],times_per_year=12) + other_incomes.total(times_per_year=12)),symbol="") }
-          % elif employed:
-          ${ currency(jobs.gross_total(source=["full time","part time"],times_per_year=12) + other_incomes.total(times_per_year=12),symbol="") }
+          ${ currency(jobs.gross_total(times_per_year=12) + other_incomes.total(times_per_year=12),symbol="") }
+
           % elif other_incomes.selected_types.any_true():
 
           ${ currency(other_incomes.total(times_per_year=12),symbol="") }
@@ -2297,9 +2293,9 @@ attachments:
           % endif
       - "users1_income_annual_total": |
           % if defined("jobs"):
-          ${ currency(float(jobs.gross_total(source=["full time","part time","self employed"],times_per_year=1) + other_incomes.total(times_per_year=1)),symbol="") }
+          ${ currency(float(jobs.gross_total(times_per_year=1) + other_incomes.total(times_per_year=1)),symbol="") }
           % elif employed:
-          ${ currency(jobs.gross_total(source=["full time","part time"],times_per_year=1) + other_incomes.total(times_per_year=1),symbol="") }
+          ${ currency(jobs.gross_total(times_per_year=1) + other_incomes.total(times_per_year=1),symbol="") }
           % elif other_incomes.number_gathered() > 0:
           ${ currency(other_incomes.total(times_per_year=1),symbol="") }
           % else:

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='docassemble.VTFeeWaiver',
       url='https://VTLawHelp.org/VTCourtForms',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.11.1', 'docassemble.AssemblyLine>=3.1.0', 'docassemble.GithubFeedbackForm>=0.4.0', 'docassemble.VTFeedback', 'docassemble.VTSharedYMLFile'],
+      install_requires=['docassemble.ALToolbox>=0.11.0', 'docassemble.AssemblyLine>=3.1.0', 'docassemble.GithubFeedbackForm>=0.4.0', 'docassemble.VTFeedback', 'docassemble.VTSharedYMLFile'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/VTFeeWaiver/', package='docassemble.VTFeeWaiver'),
      )


### PR DESCRIPTION
Used source and exclude_source in the total methods to get the right amounts for Gross Income from Wages, Total Montly Incomes, and Total Income in the Past 12 monhs

Also, I was confused why self-employed income wasn't showing up, until I realized that there was a line return before the answer, so it would only show on the form if you clicked into the field.  This seems like it may be a problem in other fields as well.