### PR TITLE
Adobe pdf issue remove currency

### DIFF
--- a/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
+++ b/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
@@ -399,7 +399,8 @@ fields:
       variable: public_benefits[i].source
       is: Medicaid or Dr Dynasaur
   - Amount of income: public_benefits[i].value
-    datatype: currency
+    datatype: 
+    
     hide if:
       variable: public_benefits[i].source
       is: Medicaid or Dr Dynasaur
@@ -2375,7 +2376,7 @@ attachments:
           % if jobs.total(times_per_year=12,exclude_source=["self employed"]) == 0:
           
           % else:
-          ${ currency(jobs.gross_total(exclude_source=["self employed"], times_per_year=12),symbol="") }
+          ${ jobs.gross_total(exclude_source=["self employed"],times_per_year=12) }
           % endif
       
       - "users1_income_unemployment_monthly_amount": |
@@ -2408,20 +2409,20 @@ attachments:
           
       - "users1_income_monthly_total": |
           % if defined("jobs"):
-          ${ currency(jobs.gross_total(times_per_year=12) + other_incomes.total(times_per_year=12),symbol="") }
+          ${ jobs.gross_total(times_per_year=12) + other_incomes.total(times_per_year=12) }
           % elif other_incomes.number_gathered() > 0:
-          ${ currency(other_incomes.total(times_per_year=12),symbol="") }
+          ${ other_incomes.total(times_per_year=12) }
           % else:
           0.00      
           % endif
           
       - "users1_income_annual_total": |
           % if defined("jobs"):
-          ${ currency(float(jobs.gross_total(times_per_year=1) + other_incomes.total(times_per_year=1)),symbol="") }
+          ${ jobs.gross_total(times_per_year=1) + other_incomes.total(times_per_year=1) }
           % elif employed:
-          ${ currency(jobs.gross_total(times_per_year=1) + other_incomes.total(times_per_year=1),symbol="") }
+          ${ jobs.gross_total(times_per_year=1) + other_incomes.total(times_per_year=1) }
           % elif other_incomes.number_gathered() > 0:
-          ${ currency(other_incomes.total(times_per_year=1),symbol="") }
+          ${ other_incomes.total(times_per_year=1) }
           % else:
           0.00      
           % endif

--- a/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
+++ b/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
@@ -2369,62 +2369,62 @@ attachments:
           % elif public_benefits.number_gathered() == 2 and public_benefits[0].source == "Dr Dynasaur" and public_benefits[1].source == "Medicaid":
           Varies        
           % else:
-          ${ currency(public_benefits.total(times_per_year=12),symbol="") }
+          ${ round(currency(public_benefits.total(times_per_year=12),symbol=""), 2) }
           % endif
       
       - "users1_income_employment_monthly_amount": |
           % if jobs.total(times_per_year=12,exclude_source=["self employed"]) == 0:
           
           % else:
-          ${ jobs.gross_total(exclude_source=["self employed"],times_per_year=12) }
+          ${ round(jobs.gross_total(exclude_source=["self employed"],times_per_year=12), 2) }
           % endif
       
       - "users1_income_unemployment_monthly_amount": |
           % if other_incomes.total(source=["unemployment income"],times_per_year=12) == 0:
            
           % else:
-          ${ currency(other_incomes.total(source=["unemployment income"],times_per_year=12),symbol="") }
+          ${ round(other_incomes.total(source=["unemployment income"],times_per_year=12), 2) }
           % endif      
 
       - "users1_income_child_support_monthly_amount": |
           % if other_incomes.total(source=["child support income"],times_per_year=12) == 0:
             
           % else:
-          ${ currency(other_incomes.total(source=["child support income"],times_per_year=12),symbol="") }
+          ${ round(other_incomes.total(source=["child support income"],times_per_year=12), 2) }
           % endif           
       
       - "users1_income_other_monthly_amount": |
           % if other_incomes.total(exclude_source=["unemployment income","child support income"],times_per_year=12) == 0:
             
           % else:
-          ${ currency(other_incomes.total(exclude_source=["unemployment income","child support income"],times_per_year=12),symbol="") }
+          ${ round(other_incomes.total(exclude_source=["unemployment income","child support income"],times_per_year=12), 2) }
           % endif   
       
       - "users1_income_self_employment_monthly_amount": |
           % if jobs.total(source=["self employed"],times_per_year=12) != 0:
-          ${ currency(jobs.total(source=["self employed"],times_per_year=12),symbol="") }
+          ${ round(jobs.total(source=["self employed"],times_per_year=12), 2) }
           % else:
           
           % endif
           
       - "users1_income_monthly_total": |
           % if defined("jobs"):
-          ${ jobs.gross_total(times_per_year=12) + other_incomes.total(times_per_year=12) }
+          ${ round(jobs.gross_total(times_per_year=12) + other_incomes.total(times_per_year=12), 2) }
           % elif other_incomes.number_gathered() > 0:
-          ${ other_incomes.total(times_per_year=12) }
+          ${ round(other_incomes.total(times_per_year=12), 2) }
           % else:
-          0.00      
+          ${ round(0, 2) }   
           % endif
           
       - "users1_income_annual_total": |
           % if defined("jobs"):
-          ${ jobs.gross_total(times_per_year=1) + other_incomes.total(times_per_year=1) }
+          ${ round(jobs.gross_total(times_per_year=1) + other_incomes.total(times_per_year=1), 2) }
           % elif employed:
-          ${ jobs.gross_total(times_per_year=1) + other_incomes.total(times_per_year=1) }
+          ${ round(jobs.gross_total(times_per_year=1) + other_incomes.total(times_per_year=1), 2) }
           % elif other_incomes.number_gathered() > 0:
-          ${ other_incomes.total(times_per_year=1) }
+          ${ round(other_incomes.total(times_per_year=1), 2) }
           % else:
-          0.00      
+          ${ round(0, 2) }     
           % endif
 
       
@@ -2432,77 +2432,77 @@ attachments:
           % if expenses.total(source=["rent"],times_per_year=12) + expenses.total(source=["mortgage"],times_per_year=12) == 0:
            
           % else:
-          ${ currency(expenses.total(source=["rent"],times_per_year=12) + expenses.total(source=["mortgage"],times_per_year=12),symbol="") }  
+          ${ round(expenses.total(source=["rent"],times_per_year=12) + expenses.total(source=["mortgage"],times_per_year=12), 2) }  
           % endif      
        
       - "users1_expenses_electric_monthly_amount": |
           % if expenses.total(source=["electric"],times_per_year=12) == 0:
            
           % else:
-          ${ currency(expenses.total(source=["electric"],times_per_year=12),symbol="") }   
+          ${ expenses.total(source=["electric"],times_per_year=12) }   
           % endif  
          
       - "users1_expenses_phone_monthly_amount": |
           % if expenses.total(source=["phone"],times_per_year=12) == 0:
            
           % else:
-          ${ currency(expenses.total(source=["phone"],times_per_year=12),symbol="") }   
+          ${ expenses.total(source=["phone"],times_per_year=12) }   
           % endif  
       - "users1_expenses_fuel_monthly_amount": |
           % if expenses.total(source=["fuel"],times_per_year=12) == 0:
            
           % else:
-          ${ currency(expenses.total(source=["fuel"],times_per_year=12),symbol="") }   
+          ${ expenses.total(source=["fuel"],times_per_year=12) }   
           % endif  
       - "users1_expenses_food_monthly_amount": |
           % if expenses.total(source=["food"],times_per_year=12) == 0:
            
           % else:
-          ${ currency(expenses.total(source=["food"],times_per_year=12),symbol="") }   
+          ${ expenses.total(source=["food"],times_per_year=12) }   
           % endif  
       - "users1_expenses_clothes_monthly_amount": |
           % if expenses.total(source=["clothing"],times_per_year=12) == 0:
            
           % else:
-          ${ currency(expenses.total(source=["clothing"],times_per_year=12),symbol="") }   
+          ${ expenses.total(source=["clothing"],times_per_year=12) }   
           % endif  
       - "users1_expenses_medical_monthly_amount": |
           % if expenses.total(source=["medical"],times_per_year=12) == 0:
            
           % else:
-          ${ currency(expenses.total(source=["medical"],times_per_year=12),symbol="") }   
+          ${ expenses.total(source=["medical"],times_per_year=12) }   
           % endif  
       - "users1_expenses_child_support_monthly_amount": |
           % if expenses.total(source=["child support"],times_per_year=12) == 0:
            
           % else:
-          ${ currency(expenses.total(source=["child support"],times_per_year=12),symbol="") }   
+          ${ expenses.total(source=["child support"],times_per_year=12) }   
           % endif  
       - "users1_expenses_auto_loan_monthly_amount": |
           % if expenses.total(source=["auto loan"],times_per_year=12) == 0:
            
           % else:
-          ${ currency(expenses.total(source=["auto loan"],times_per_year=12),symbol="") }   
+          ${ expenses.total(source=["auto loan"],times_per_year=12) }   
           % endif  
       - "users1_expenses_property_tax_monthly_amount": |
           % if expenses.total(source=["property tax"],times_per_year=12) == 0:
            
           % else:
-          ${ currency(expenses.total(source=["property tax"],times_per_year=12),symbol="") }   
+          ${ expenses.total(source=["property tax"],times_per_year=12) }   
           % endif  
       - "users1_expenses_all_insurance_monthly_amount": |
           % if expenses.total(source=["health insurance", "auto insurance", "other insurance"],times_per_year=12) == 0:
            
           % else:
-          ${ currency(expenses.total(source=["health insurance", "auto insurance", "other insurance"],times_per_year=12),symbol="") }  
+          ${ expenses.total(source=["health insurance", "auto insurance", "other insurance"],times_per_year=12) }  
           % endif  
       - "users1_expenses_other_monthly_amount": |
           % if expenses.total(exclude_source=["rent", "mortgage", "electric", "phone", "fuel", "food", "clothing", "medical", "child support", "auto loan", "property tax", "health insurance", "auto insurance", "other insurance" ],times_per_year=12) == 0:
            
           % else:
-          ${ currency(expenses.total(exclude_source=["rent", "mortgage", "electric", "phone", "fuel", "food", "clothing", "medical", "child support", "auto loan", "property tax", "health insurance", "auto insurance", "other insurance" ],times_per_year=12),symbol="") } 
+          ${ expenses.total(exclude_source=["rent", "mortgage", "electric", "phone", "fuel", "food", "clothing", "medical", "child support", "auto loan", "property tax", "health insurance", "auto insurance", "other insurance" ],times_per_year=12) } 
           % endif  
-      - "users1_expenses_monthly_total": ${ currency(expenses.total(times_per_year=12),symbol="") }
+      - "users1_expenses_monthly_total": ${ round(expenses.total(times_per_year=12), 2) }
       
       - "assets_yes": |
           % if vehicles.number_gathered() > 0:


### PR DESCRIPTION
When using currency() around ALIncome computed figures for the PDF, we found that we were getting weird characters when we viewed the resulting PDF in Adobe. The problem has something to do with strings vs. numbers.

![image](https://github.com/user-attachments/assets/24130d90-6f51-4757-966d-c4054bc4cf50)
See: https://teams.microsoft.com/l/message/19:e16e9e9701a5445ea4035b5cb776a4cc@thread.tacv2/1729203442812?tenantId=78733fa9-540e-4eb8-bf29-73c4eeb63412&groupId=eaa9bd9d-cf39-4686-8f30-e55aa9d98c75&parentMessageId=1729203442812&teamName=Document%20Assembly%20Line&channelName=Coding%20help&createdTime=1729203442812

So now using round(number, 2) instead of currency to get 2 decimal places in the ALIncome computed figures that go on the PDF.

The reason we need this is because using ALIncome we collect dollar amounts for income and expenses and let the user choose how often they get or pay that amount. So we don't always get neat numbers!
 
Only drawback I see so far is that browsers don't show the commas for thousands. The commas show up in Adobe, however.