### PR TITLE
Fixed missing "currency" in id: public benefits info for list

### DIFF
--- a/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
+++ b/docassemble/VTFeeWaiver/data/questions/VT_fee_waiver.yml
@@ -399,8 +399,7 @@ fields:
       variable: public_benefits[i].source
       is: Medicaid or Dr Dynasaur
   - Amount of income: public_benefits[i].value
-    datatype: 
-    
+    datatype: currency    
     hide if:
       variable: public_benefits[i].source
       is: Medicaid or Dr Dynasaur


### PR DESCRIPTION
I had accidentally deleted it.